### PR TITLE
chore: compound loop update after MVP merge

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -8,3 +8,12 @@
   - PR creation raced branch indexing immediately after push.
 - Preventive rule:
   - Always push branch first, then create PR in a separate command.
+
+## 2026-02-17 - Loop 1 (MVP Integration Merge)
+
+- Hard part:
+  - Branch protection required an external reviewer and blocked merge despite green CI.
+- What broke:
+  - Self-approval is disallowed, so standard merge flow could not complete from a single-account automation context.
+- Preventive rule:
+  - For protected branches, assign a reviewer at PR creation time and avoid end-of-cycle merge blocking.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -6,6 +6,7 @@
 - Do include `(#issue)` in every commit message.
 - Do open PRs to `main` only.
 - Do merge PRs only after CI passes.
+- Do request reviewer assignment immediately for protected branches.
 - Do not commit directly to `main`.
 - Do not force-push `main`.
 - Do not rewrite history of merged PRs.


### PR DESCRIPTION
## Summary
- update docs/compound/lessons.md with Loop 1 merge learnings
- update docs/compound/rules.md with reviewer-assignment guardrail for protected branches

## Validation
- docs-only change

## Compound Summary
- What was hard? Merge policy required external review despite green CI.
- What broke? Single-account flow could not self-approve.
- What rule prevents it next time? Assign reviewer immediately when PR is created for protected branches.

Closes #14