### PR TITLE
chore: compound update after PR1 merge

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -17,3 +17,12 @@
   - Self-approval is disallowed, so standard merge flow could not complete from a single-account automation context.
 - Preventive rule:
   - For protected branches, assign a reviewer at PR creation time and avoid end-of-cycle merge blocking.
+
+## 2026-02-17 - Loop 2 (PR1 Question Pool)
+
+- Hard part:
+  - Building pool behavior that handles under-filled banks without returning server errors.
+- What broke:
+  - During tests, pool could be empty before fixture setup, causing false assumptions about warmup state.
+- Preventive rule:
+  - All pool-backed endpoints must include deterministic DB fallback and explicit warning logs.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -17,6 +17,7 @@
 - Do run backend and frontend checks before merge.
 - Do keep real secrets and API keys out of git.
 - Do maintain `.env.example` with placeholder values only.
+- Do require fallback paths for any cache/pool-dependent API route.
 
 ## Compound Loop
 


### PR DESCRIPTION
## Summary
- update docs/compound/lessons.md with PR1 (question pool) learnings
- update docs/compound/rules.md with cache fallback guardrail

## Validation
- docs-only change

## Compound Summary
- What was hard? Keeping pool behavior reliable while bank volume is below long-term target.
- What broke? Warmup assumptions during test lifecycle.
- What rule prevents it next time? Every cache/pool endpoint must have deterministic DB fallback and warning logs.

Closes #23