### PR TITLE
chore: compound update after PR2 merge

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -26,3 +26,12 @@
   - During tests, pool could be empty before fixture setup, causing false assumptions about warmup state.
 - Preventive rule:
   - All pool-backed endpoints must include deterministic DB fallback and explicit warning logs.
+
+## 2026-02-17 - Loop 3 (PR2 Session De-dup)
+
+- Hard part:
+  - Combining pool-based retrieval with per-session exclusion logic while preserving fallback reliability.
+- What broke:
+  - Exclusion query requires separate handling for empty and non-empty exclusion sets.
+- Preventive rule:
+  - For exclusion-based random fetches, always branch query path on whether exclusion set is empty.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -27,3 +27,4 @@
   - what was hard
   - what broke
   - the rule to prevent it next time
+- For session-dedup APIs, include tests that make repeated requests for the same session and assert non-duplication.


### PR DESCRIPTION
## Summary
- add loop-3 learning entry for session de-dup implementation
- add rule requiring repeat-session non-duplication tests

## Validation
- docs-only change

## Compound Summary
- What was hard? Integrating exclusion semantics with pooled retrieval and fallback.
- What broke? Empty vs non-empty exclusion paths require explicit query branching.
- What rule prevents it next time? Always branch exclusion queries by empty/non-empty set and test both paths.

Closes #26