### PR TITLE
chore: compound update after PRs #27 and #28

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -35,3 +35,21 @@
   - Exclusion query requires separate handling for empty and non-empty exclusion sets.
 - Preventive rule:
   - For exclusion-based random fetches, always branch query path on whether exclusion set is empty.
+
+## 2026-02-17 - Loop 4 (Compound Follow-up PR Merge)
+
+- Hard part:
+  - Keeping mandatory compound-update cadence while multiple feature PRs are in-flight.
+- What broke:
+  - Merge sequencing can drift if compound PR is not treated as a first-class step.
+- Preventive rule:
+  - Reserve a dedicated post-merge slot for compound updates before starting the next feature PR.
+
+## 2026-02-17 - Loop 5 (PR3 Pipeline Hardening Merge)
+
+- Hard part:
+  - Applying stricter validator rules without stalling pipeline execution on legacy fixtures.
+- What broke:
+  - Full-directory validation failed because legacy files did not satisfy new option uniqueness checks.
+- Preventive rule:
+  - Validate the approved artifact generated in the same run, and track legacy fixture cleanup separately.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -28,3 +28,4 @@
   - what broke
   - the rule to prevent it next time
 - For session-dedup APIs, include tests that make repeated requests for the same session and assert non-duplication.
+- Treat compound-update PR merge as a required gate before starting the next feature branch.


### PR DESCRIPTION
## Summary
- add loop entries for PR #27 merge cadence and PR #28 pipeline lessons
- add rule requiring compound-update merge before next feature branch

## Validation
- docs-only change

## Compound Summary
- What was hard? Maintaining strict compound cadence while sequential PRs merged quickly.
- What broke? Merge sequencing can drift without explicit gating.
- What rule prevents it next time? Always complete compound-update PR merge before next feature branch starts.

Closes #29