### PR TITLE
chore: compound update after PR #30 merge

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -53,3 +53,12 @@
   - Full-directory validation failed because legacy files did not satisfy new option uniqueness checks.
 - Preventive rule:
   - Validate the approved artifact generated in the same run, and track legacy fixture cleanup separately.
+
+## 2026-02-17 - Loop 6 (PR30 Compound Gate Merge)
+
+- Hard part:
+  - Branch divergence after rapid PR merges can interrupt the strict loop cadence.
+- What broke:
+  - `git pull --ff-only` failed due local divergence against updated origin/main.
+- Preventive rule:
+  - If `--ff-only` fails during loop execution, rebase immediately on `origin/main` before any new branch work.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -29,3 +29,4 @@
   - the rule to prevent it next time
 - For session-dedup APIs, include tests that make repeated requests for the same session and assert non-duplication.
 - Treat compound-update PR merge as a required gate before starting the next feature branch.
+- When `git pull --ff-only` fails, run `git rebase origin/main` before continuing.


### PR DESCRIPTION
## Summary
- add loop-6 lessons about resolving main divergence during rapid merge cadence
- add explicit rebase guardrail to compound rules

## Validation
- docs-only change

## Compound Summary
- What was hard? Keeping loop cadence intact while main moved quickly.
- What broke? fast-forward pull failed due divergence.
- What rule prevents it next time? rebase on origin/main immediately when ff-only fails.

Closes #31