### PR TITLE
chore: compound update after PR #33 merge

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -62,3 +62,12 @@
   - `git pull --ff-only` failed due local divergence against updated origin/main.
 - Preventive rule:
   - If `--ff-only` fails during loop execution, rebase immediately on `origin/main` before any new branch work.
+
+## 2026-02-17 - Loop 7 (PR4 Scheduler Merge)
+
+- Hard part:
+  - Verifying scheduler command path without polluting PR scope with regenerated data artifacts.
+- What broke:
+  - Local verification rewrote generated files and introduced noisy, non-goal diffs.
+- Preventive rule:
+  - For workflow-only PRs, restore generated artifacts unless artifact updates are explicitly part of scope.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -30,3 +30,4 @@
 - For session-dedup APIs, include tests that make repeated requests for the same session and assert non-duplication.
 - Treat compound-update PR merge as a required gate before starting the next feature branch.
 - When `git pull --ff-only` fails, run `git rebase origin/main` before continuing.
+- For scheduler/config PRs, avoid committing generated artifact churn unless explicitly required.


### PR DESCRIPTION
## Summary
- add loop-7 lessons from scheduler PR merge
- add rule to keep scheduler/config PRs free from artifact churn unless intentional

## Validation
- docs-only change

## Compound Summary
- What was hard? Validating scheduler flow without generating noisy diffs.
- What broke? Verification runs rewrote generated artifacts by default.
- What rule prevents it next time? Restore generated artifacts for workflow-only PRs unless artifact updates are explicitly intended.

Closes #34