### PR TITLE
chore: compound update after PR #35 merge

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -71,3 +71,12 @@
   - Local verification rewrote generated files and introduced noisy, non-goal diffs.
 - Preventive rule:
   - For workflow-only PRs, restore generated artifacts unless artifact updates are explicitly part of scope.
+
+## 2026-02-17 - Loop 8 (PR35 Compound Merge)
+
+- Hard part:
+  - High merge frequency increases risk of skipping mandatory loop bookkeeping.
+- What broke:
+  - None functionally, but compliance overhead is easy to miss without explicit tracking issues.
+- Preventive rule:
+  - Create a dedicated tracking issue for every post-merge compound update and close it only after merge.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -31,3 +31,4 @@
 - Treat compound-update PR merge as a required gate before starting the next feature branch.
 - When `git pull --ff-only` fails, run `git rebase origin/main` before continuing.
 - For scheduler/config PRs, avoid committing generated artifact churn unless explicitly required.
+- Open one tracking issue per mandatory post-merge compound update and close via the compound PR.


### PR DESCRIPTION
## Summary
- add loop-8 entry for merge-cadence compliance handling
- add rule requiring one tracking issue per post-merge compound update

## Validation
- docs-only change

## Compound Summary
- What was hard? Maintaining compliance while merge cadence is high.
- What broke? No functional break, but process compliance can be skipped without explicit tracking.
- What rule prevents it next time? Track each post-merge compound update via dedicated issue and close through the corresponding PR.

Closes #36