### PR TITLE
chore: compound update after PR #38 merge

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -80,3 +80,12 @@
   - None functionally, but compliance overhead is easy to miss without explicit tracking issues.
 - Preventive rule:
   - Create a dedicated tracking issue for every post-merge compound update and close it only after merge.
+
+## 2026-02-17 - Loop 9 (PR5 Deployment Merge)
+
+- Hard part:
+  - Keeping branch alignment stable while merging many sequential PRs with strict gating.
+- What broke:
+  - Repeated `--ff-only` pull failures due local divergence after merge cadence.
+- Preventive rule:
+  - Standardize on `git rebase origin/main` as the immediate recovery path before starting each follow-up loop.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -32,3 +32,4 @@
 - When `git pull --ff-only` fails, run `git rebase origin/main` before continuing.
 - For scheduler/config PRs, avoid committing generated artifact churn unless explicitly required.
 - Open one tracking issue per mandatory post-merge compound update and close via the compound PR.
+- Before each new branch in high-cadence merge periods, verify branch base with `git status --branch` and rebase if needed.


### PR DESCRIPTION
## Summary
- add loop-9 lessons after deployment PR merge
- add rule to verify branch base before each new branch in high-cadence periods

## Validation
- docs-only change

## Compound Summary
- What was hard? Maintaining branch alignment under high merge cadence.
- What broke? repeated ff-only pull failures due divergence.
- What rule prevents it next time? verify branch base and rebase on origin/main before starting each loop.

Closes #39