### PR TITLE
chore: compound update after production phase merge

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -89,3 +89,12 @@
   - Repeated `--ff-only` pull failures due local divergence after merge cadence.
 - Preventive rule:
   - Standardize on `git rebase origin/main` as the immediate recovery path before starting each follow-up loop.
+
+## 2026-02-17 - Loop 10 (Production Phase Merge)
+
+- Hard part:
+  - Shipping observability, bank guarantees, concurrency safety, workflow dry-run, and deploy hardening together without breaking runtime behavior.
+- What broke:
+  - Prometheus endpoint test initially failed until explicit prometheus export config was enabled.
+- Preventive rule:
+  - When adding new actuator-backed metrics, verify endpoint exposure settings in integration tests, not only dependency declarations.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -33,3 +33,4 @@
 - For scheduler/config PRs, avoid committing generated artifact churn unless explicitly required.
 - Open one tracking issue per mandatory post-merge compound update and close via the compound PR.
 - Before each new branch in high-cadence merge periods, verify branch base with `git status --branch` and rebase if needed.
+- For observability rollouts, add an integration test that hits the expected actuator/internal endpoint.


### PR DESCRIPTION
## Summary
- add loop-10 lessons for production-phase merge
- add observability rollout rule for endpoint integration testing

## Validation
- docs-only change

## Compound Summary
- What was hard? Coordinating multi-phase production hardening without regressions.
- What broke? Prometheus endpoint test initially failed due exposure config mismatch.
- What rule prevents it next time? actuator/internal observability changes must include endpoint integration checks.

Closes #42