### PR TITLE
Phase A: public deploy wiring and smoke tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,8 @@ API_BASE_URL=http://localhost:8080
 VITE_API_BASE_URL=http://localhost:8080
 BACKEND_PUBLIC_URL=https://smartiq-backend.onrender.com
 FRONTEND_PUBLIC_URL=https://smartiq.vercel.app
+BACKEND_URL=https://smartiq-backend.onrender.com
+VITE_BACKEND_URL=https://smartiq-backend.onrender.com
 
 # Data/content pipeline
 RAW_DATA_PATH=./data/raw

--- a/.github/workflows/smoke-public.yml
+++ b/.github/workflows/smoke-public.yml
@@ -1,0 +1,30 @@
+name: Public Smoke Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend_url:
+        description: "Public backend base URL (https://...)"
+        required: true
+        type: string
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js LTS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run smoke test
+        env:
+          BACKEND_URL: ${{ inputs.backend_url }}
+        run: npm run smoke:test

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Endpoints:
 - Frontend: `http://localhost:5173`
 - Backend API: `http://localhost:8080/api`
 - Backend health: `http://localhost:8080/health`
+- Backend version: `http://localhost:8080/version`
 - Backend metrics: `http://localhost:8080/actuator/prometheus`
 - Internal pool stats: `http://localhost:8080/internal/pool-stats`
 
@@ -97,6 +98,12 @@ Load test (500 sessions / 10k requests default):
 
 ```bash
 npm run load:test
+```
+
+Public smoke test:
+
+```bash
+BACKEND_URL=https://<backend-domain> npm run smoke:test
 ```
 
 Stability gate (production readiness check):

--- a/backend/src/main/java/com/smartiq/backend/web/VersionController.java
+++ b/backend/src/main/java/com/smartiq/backend/web/VersionController.java
@@ -1,0 +1,25 @@
+package com.smartiq.backend.web;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class VersionController {
+
+    @Value("${smartiq.build.commit-sha:unknown}")
+    private String commitSha;
+
+    @Value("${smartiq.build.time:unknown}")
+    private String buildTime;
+
+    @GetMapping("/version")
+    public Map<String, String> version() {
+        return Map.of(
+                "commitSha", commitSha,
+                "buildTime", buildTime
+        );
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -27,6 +27,9 @@ management:
       show-details: never
 
 smartiq:
+  build:
+    commit-sha: ${SMARTIQ_BUILD_SHA:unknown}
+    time: ${SMARTIQ_BUILD_TIME:unknown}
   import:
     enabled: ${SMARTIQ_IMPORT_ENABLED:true}
     path: ${SMARTIQ_IMPORT_PATH:../data/clean}

--- a/backend/src/test/java/com/smartiq/backend/card/CardControllerTest.java
+++ b/backend/src/test/java/com/smartiq/backend/card/CardControllerTest.java
@@ -152,6 +152,14 @@ class CardControllerTest {
     }
 
     @Test
+    void versionEndpointIsAvailable() throws Exception {
+        mockMvc.perform(get("/version"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.commitSha").exists())
+                .andExpect(jsonPath("$.buildTime").exists());
+    }
+
+    @Test
     void poolStatsEndpointIsAvailable() throws Exception {
         mockMvc.perform(get("/internal/pool-stats"))
                 .andExpect(status().isOk());

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -48,6 +48,8 @@ Create a Vercel project from this repository:
 Set frontend environment variable:
 
 - `VITE_API_BASE_URL=https://<your-backend-domain>`
+- Optional alias: `VITE_BACKEND_URL=https://<your-backend-domain>`
+- Team-facing var naming: `BACKEND_URL=https://<your-backend-domain>` (map to `VITE_*` in Vercel env)
 
 Validate deployment env vars locally:
 
@@ -60,3 +62,9 @@ npm run validate:deploy-env
 1. `GET https://<backend-domain>/health` returns `{\"status\":\"UP\"}`.
 2. Frontend loads topics from backend.
 3. `/api/cards/next` works from deployed frontend domain without CORS errors.
+
+Public smoke test command:
+
+```bash
+BACKEND_URL=https://<backend-domain> npm run smoke:test
+```

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,7 @@
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8080';
+const API_BASE =
+  import.meta.env.VITE_API_BASE_URL ||
+  import.meta.env.VITE_BACKEND_URL ||
+  'http://localhost:8080';
 
 export async function fetchTopics() {
   const res = await fetch(`${API_BASE}/api/topics`);

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "validate:cards": "node tools/validate-cards.js data/clean",
     "pipeline:cards": "node tools/build-content-pipeline.js",
     "load:test": "node tools/load-test.js",
+    "smoke:test": "node tools/smoke-test.js",
     "validate:deploy-env": "node tools/validate-deploy-env.js",
     "stability:gate": "node tools/stability-gate.js"
   },

--- a/tools/smoke-test.js
+++ b/tools/smoke-test.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const baseUrl = (process.env.BACKEND_URL || '').trim();
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function getJson(url) {
+  const res = await fetch(url);
+  const text = await res.text();
+  let json = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { status: res.status, json, text };
+}
+
+function validateCard(card) {
+  assert(card && typeof card === 'object', 'Card payload must be an object');
+  const required = ['id', 'topic', 'language', 'question', 'options', 'difficulty', 'source', 'createdAt'];
+  for (const key of required) {
+    assert(card[key] !== undefined && card[key] !== null, `Card missing field: ${key}`);
+  }
+  assert(Array.isArray(card.options), 'Card options must be array');
+  assert(card.options.length === 10, 'Card options must have length 10');
+}
+
+async function main() {
+  if (!baseUrl) {
+    throw new Error('BACKEND_URL is required. Example: BACKEND_URL=https://smartiq-backend.onrender.com');
+  }
+
+  const health = await getJson(`${baseUrl}/health`);
+  assert(health.status === 200, `/health expected 200 got ${health.status}`);
+
+  const topics = await getJson(`${baseUrl}/api/topics`);
+  assert(topics.status === 200, `/api/topics expected 200 got ${topics.status}`);
+  assert(Array.isArray(topics.json), '/api/topics must return array');
+
+  const card = await getJson(`${baseUrl}/api/cards/next?topic=Math&difficulty=2&sessionId=smoke&lang=en`);
+  assert(card.status === 200, `/api/cards/next expected 200 got ${card.status}`);
+  validateCard(card.json);
+
+  console.log(JSON.stringify({ ok: true, baseUrl }, null, 2));
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Scope Checklist\n- [x] add /version endpoint (commit sha + build time)\n- [x] document Vercel/Render backend URL env wiring\n- [x] add smoke test script for /health, /api/topics, /api/cards/next schema\n- [x] add workflow-dispatch smoke workflow (.github/workflows/smoke-public.yml)\n\n## Validation\n- cd backend && mvn -q test\n- 
pm --prefix frontend ci && npm --prefix frontend run lint && npm --prefix frontend run build\n\n## Compound Summary\n- What was hard? keeping deploy env naming compatible with Vercel while preserving existing frontend config.\n- What broke? nothing functionally; needed explicit aliasing docs for BACKEND_URL vs VITE_*.\n- What rule prevents it next time? every public deploy step must include a runnable smoke script with explicit env contract.\n\nCloses #45\nRefs #44