### PR TITLE
chore: compound update after Phase A

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -98,3 +98,12 @@
   - Prometheus endpoint test initially failed until explicit prometheus export config was enabled.
 - Preventive rule:
   - When adding new actuator-backed metrics, verify endpoint exposure settings in integration tests, not only dependency declarations.
+
+## 2026-02-17 - Loop 11 (Phase A Merge)
+
+- Hard part:
+  - Keeping deploy variable naming compatible across Vercel (`VITE_*`) and team-level `BACKEND_URL` conventions.
+- What broke:
+  - Local branch state drifted after squash merge and required explicit main realignment.
+- Preventive rule:
+  - After squash merges, reset local `main` to `origin/main` before starting next phase branch.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -34,3 +34,4 @@
 - Open one tracking issue per mandatory post-merge compound update and close via the compound PR.
 - Before each new branch in high-cadence merge periods, verify branch base with `git status --branch` and rebase if needed.
 - For observability rollouts, add an integration test that hits the expected actuator/internal endpoint.
+- After squash merge cycles, prefer `git checkout -B main origin/main` to avoid local drift.


### PR DESCRIPTION
## Summary
- record Phase A merge learnings and drift prevention rule

## Validation
- docs-only change

## Compound Summary
- What was hard? keeping env naming consistent across deploy platforms.
- What broke? local main drift after squash merge.
- What rule prevents it next time? reset main to origin/main after squash-merge cycles.

Closes #47
Refs #44