### PR TITLE
chore(docs): compound update after Phase B

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -107,3 +107,12 @@
   - Local branch state drifted after squash merge and required explicit main realignment.
 - Preventive rule:
   - After squash merges, reset local `main` to `origin/main` before starting next phase branch.
+
+## 2026-02-17 - Loop 12 (Phase B Merge)
+
+- Hard part:
+  - Moving from single-question demo flow to a full multi-player round without breaking session de-dup behavior.
+- What broke:
+  - First card fetch could use stale `sessionId` state if fetch started before React state commit.
+- Preventive rule:
+  - For first request in a new session, pass freshly generated session ID directly to API call, not through async state only.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -35,3 +35,4 @@
 - Before each new branch in high-cadence merge periods, verify branch base with `git status --branch` and rebase if needed.
 - For observability rollouts, add an integration test that hits the expected actuator/internal endpoint.
 - After squash merge cycles, prefer `git checkout -B main origin/main` to avoid local drift.
+- For new gameplay sessions, use the freshly generated `sessionId` directly in the first backend request to avoid stale-state fetches.


### PR DESCRIPTION
## Summary
- add Loop 12 lesson entry for Phase B merge
- add gameplay session-id rule to compound rules

## Required loop notes
- What was hard: preserving session de-dup semantics during full game flow migration
- What broke: first fetch could read stale session state
- Rule: pass fresh session id directly on first fetch

Closes #51