### PR TITLE
chore(docs): compound update after Phase C

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -116,3 +116,12 @@
   - First card fetch could use stale `sessionId` state if fetch started before React state commit.
 - Preventive rule:
   - For first request in a new session, pass freshly generated session ID directly to API call, not through async state only.
+
+## 2026-02-17 - Loop 13 (Phase C Merge)
+
+- Hard part:
+  - Adding new import-focused integration tests without inheriting machine-specific datasource settings.
+- What broke:
+  - New test attempted PostgreSQL auth from environment instead of isolated H2 config and failed startup.
+- Preventive rule:
+  - Every new Spring integration test must explicitly pin test datasource properties (H2 URL/user/pass) in test annotation.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -36,3 +36,4 @@
 - For observability rollouts, add an integration test that hits the expected actuator/internal endpoint.
 - After squash merge cycles, prefer `git checkout -B main origin/main` to avoid local drift.
 - For new gameplay sessions, use the freshly generated `sessionId` directly in the first backend request to avoid stale-state fetches.
+- For every new `@SpringBootTest`, define explicit H2 datasource properties in test-local config to avoid environment-leak failures.


### PR DESCRIPTION
## Summary
- add Loop 13 lesson entry for Phase C merge
- add spring integration-test datasource pinning rule

## Required loop notes
- What was hard: avoiding env-specific datasource leakage in new tests
- What broke: startup failed from PostgreSQL auth in local env
- Rule: always pin H2 datasource properties in new Spring integration tests

Closes #55