### PR TITLE
chore(docs): compound update after Phase D

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -125,3 +125,12 @@
   - New test attempted PostgreSQL auth from environment instead of isolated H2 config and failed startup.
 - Preventive rule:
   - Every new Spring integration test must explicitly pin test datasource properties (H2 URL/user/pass) in test annotation.
+
+## 2026-02-17 - Loop 14 (Phase D Merge)
+
+- Hard part:
+  - Hardening internal/public endpoint boundaries without breaking public health and gameplay routes.
+- What broke:
+  - Security filter behavior can silently drift without prod-profile integration coverage.
+- Preventive rule:
+  - Every prod-only access control change must include MockMvc tests that assert both blocked and allowed paths.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -37,3 +37,4 @@
 - After squash merge cycles, prefer `git checkout -B main origin/main` to avoid local drift.
 - For new gameplay sessions, use the freshly generated `sessionId` directly in the first backend request to avoid stale-state fetches.
 - For every new `@SpringBootTest`, define explicit H2 datasource properties in test-local config to avoid environment-leak failures.
+- For prod access-control filters, add tests that verify unauthenticated denial and authenticated success on protected endpoints.


### PR DESCRIPTION
## Summary
- add Loop 14 lesson entry for Phase D merge
- add rule requiring prod access-control allow/deny tests

## Required loop notes
- What was hard: protecting internal routes while preserving public APIs
- What broke: risk of silent behavior drift without prod-profile tests
- Rule: require blocked + allowed MockMvc assertions for prod access filters

Closes #59