### PR TITLE
feat(ui): Smart10-style game board layout components

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -8,7 +8,7 @@ export default [
   },
   js.configs.recommended,
   {
-    files: ['**/*.{js,jsx}'],
+    files: ['**/*.{js,jsx,ts,tsx}'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',

--- a/frontend/src/components/AnswerTile.tsx
+++ b/frontend/src/components/AnswerTile.tsx
@@ -1,0 +1,10 @@
+export default function AnswerTile({ index, option, state, onClick, disabled }) {
+  const className = ['answer-tile', `is-${state}`].join(' ');
+
+  return (
+    <button className={className} onClick={onClick} disabled={disabled} type="button">
+      <span className="slot-index">{index + 1}</span>
+      <span className="slot-text">{option}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -1,0 +1,86 @@
+import AnswerTile from './AnswerTile';
+import PlayersPanel from './PlayersPanel';
+
+function getTileState(index, selectedIndexes, revealed, correctIndexes) {
+  const selected = selectedIndexes.has(index);
+  if (!revealed) {
+    return selected ? 'selected' : 'hidden';
+  }
+  if (correctIndexes.has(index)) {
+    return 'correct';
+  }
+  return selected ? 'wrong' : 'revealed';
+}
+
+export default function GameBoard({
+  card,
+  selectedIndexes,
+  toggleIndex,
+  revealed,
+  onReveal,
+  onPass,
+  onNext,
+  isLast,
+  players,
+  scores,
+  currentPlayerIndex,
+  cardIndex,
+  roundLength,
+  passNote,
+  lastAction,
+  correctIndexes
+}) {
+  return (
+    <section className="game-board">
+      <PlayersPanel
+        players={players}
+        scores={scores}
+        currentPlayerIndex={currentPlayerIndex}
+        cardIndex={cardIndex}
+        roundLength={roundLength}
+        lastAction={lastAction}
+      />
+
+      <div className="center-board board-surface">
+        <header className="card-header">
+          <p className="topic-pill">{card.topic}</p>
+          <p className="meta-line">
+            Difficulty {card.difficulty} · {card.language}
+          </p>
+          <h2>{card.question}</h2>
+          <p className="pass-note">{passNote}</p>
+        </header>
+
+        <div className="tile-grid">
+          {card.options.map((option, index) => (
+            <AnswerTile
+              key={`${card.id}-${index}`}
+              index={index}
+              option={option}
+              state={getTileState(index, selectedIndexes, revealed, correctIndexes)}
+              onClick={() => toggleIndex(index)}
+              disabled={revealed}
+            />
+          ))}
+        </div>
+
+        <footer className="action-bar">
+          {!revealed ? (
+            <>
+              <button onClick={onReveal} type="button">
+                ANSWER
+              </button>
+              <button onClick={onPass} type="button">
+                PASS
+              </button>
+            </>
+          ) : (
+            <button onClick={onNext} type="button">
+              {isLast ? 'ROUND END' : 'NEXT'}
+            </button>
+          )}
+        </footer>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/PlayersPanel.tsx
+++ b/frontend/src/components/PlayersPanel.tsx
@@ -1,0 +1,19 @@
+export default function PlayersPanel({ players, scores, currentPlayerIndex, cardIndex, roundLength, lastAction }) {
+  return (
+    <aside className="players-panel board-surface">
+      <h2>Players</h2>
+      <p className="round-line">
+        Card {cardIndex + 1} / {roundLength}
+      </p>
+      <p className="round-line">Last action: {lastAction}</p>
+      <ul>
+        {players.map((player, idx) => (
+          <li key={player} className={idx === currentPlayerIndex ? 'active' : ''}>
+            <span>{player}</span>
+            <strong>{scores[player] ?? 0}</strong>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}

--- a/frontend/src/components/RoundSummary.tsx
+++ b/frontend/src/components/RoundSummary.tsx
@@ -1,0 +1,20 @@
+export default function RoundSummary({ players, scores, roundLength, onRestart }) {
+  const sorted = [...players].sort((a, b) => (scores[b] ?? 0) - (scores[a] ?? 0));
+
+  return (
+    <section className="board-surface round-summary">
+      <h1>Round Summary</h1>
+      <p>Round length: {roundLength} cards</p>
+      <ol>
+        {sorted.map((player) => (
+          <li key={player}>
+            {player}: <strong>{scores[player] ?? 0}</strong>
+          </li>
+        ))}
+      </ol>
+      <button onClick={onRestart} type="button">
+        New round
+      </button>
+    </section>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,9 +1,11 @@
 :root {
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  line-height: 1.45;
+  font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
+  line-height: 1.4;
   font-weight: 400;
-  color: #f5f7fa;
-  background: radial-gradient(circle at top, #1f3b59, #0d1622 65%);
+  color: #fef9ef;
+  background:
+    radial-gradient(circle at 15% 10%, #3e220f 0%, #22120b 42%, #130b08 100%),
+    linear-gradient(180deg, #2f1408, #180b05);
 }
 
 * {
@@ -16,22 +18,35 @@ body {
 }
 
 main {
-  max-width: 860px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem 1rem 3rem;
+  padding: 1.25rem;
 }
 
-.panel {
-  background: rgba(11, 22, 34, 0.85);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+.board-surface {
+  background: linear-gradient(180deg, #57280f, #3f1f0d);
+  border: 1px solid rgba(255, 182, 120, 0.3);
   border-radius: 16px;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+}
+
+.setup-panel {
+  max-width: 560px;
+  margin: 0 auto;
   padding: 1.25rem;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.35);
 }
 
 h1,
-h2 {
+h2,
+h3,
+p {
   margin-top: 0;
+}
+
+label {
+  display: block;
+  font-weight: 700;
+  margin-top: 0.6rem;
 }
 
 select,
@@ -39,98 +54,191 @@ input,
 button {
   width: 100%;
   border-radius: 10px;
-  border: none;
+  border: 1px solid rgba(255, 213, 173, 0.3);
   padding: 0.7rem;
-  margin-top: 0.75rem;
+  margin-top: 0.35rem;
   font-size: 1rem;
 }
 
+select,
+input {
+  background: rgba(255, 243, 227, 0.08);
+  color: #ffefde;
+}
+
 button {
-  background: #1d7cb8;
-  color: #fff;
+  background: linear-gradient(180deg, #f59b1f, #d47117);
+  color: #2a1206;
+  font-weight: 800;
   cursor: pointer;
 }
 
 button:disabled {
-  opacity: 0.65;
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
-.question {
-  font-size: 1.1rem;
+.error {
+  color: #ffb4b4;
+}
+
+.game-board {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1rem;
+}
+
+.players-panel {
+  padding: 1rem;
+}
+
+.players-panel ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.players-panel li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.55rem 0.65rem;
+  border-radius: 10px;
+  background: rgba(255, 236, 211, 0.08);
+  border: 1px solid transparent;
+}
+
+.players-panel li.active {
+  border-color: #f9ac45;
+  background: rgba(250, 181, 77, 0.18);
+}
+
+.round-line {
+  color: #ffd7a9;
+}
+
+.center-board {
+  padding: 1rem;
+}
+
+.card-header {
+  margin-bottom: 0.8rem;
+}
+
+.topic-pill {
+  display: inline-block;
+  font-weight: 700;
+  font-size: 0.9rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  background: rgba(255, 218, 168, 0.22);
+}
+
+.meta-line {
+  color: #ffd6a4;
+  margin-top: 0.3rem;
   margin-bottom: 0.5rem;
 }
 
-.options {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
+.pass-note {
+  color: #fcd1a0;
+  margin-bottom: 0;
 }
 
-.option {
+.tile-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+.answer-tile {
   text-align: left;
-  background: rgba(255, 255, 255, 0.1);
+  padding: 0.7rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 199, 148, 0.35);
+  background: rgba(255, 240, 224, 0.08);
+  color: #fff5e6;
+  display: flex;
+  gap: 0.55rem;
+  align-items: center;
+  transition: transform 140ms ease, box-shadow 140ms ease, background 140ms ease;
 }
 
-.option.selected {
-  outline: 2px solid #69b8e6;
+.answer-tile:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
 }
 
-.option.correct {
-  background: #1d8b4e;
-}
-
-.option.wrong {
-  background: #9a2d2d;
-}
-
-.actions {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 0.5rem;
-  margin-top: 1rem;
-}
-
-.result {
-  margin-top: 0.9rem;
+.slot-index {
+  width: 1.7rem;
+  height: 1.7rem;
+  border-radius: 50%;
+  display: inline-grid;
+  place-items: center;
+  background: rgba(255, 255, 255, 0.16);
   font-weight: 700;
 }
 
-.result.ok {
-  color: #8de1b1;
+.slot-text {
+  flex: 1;
+  min-width: 0;
 }
 
-.result.fail {
-  color: #ffc2c2;
+.answer-tile.is-selected {
+  border-color: #f9ac45;
+  background: rgba(249, 172, 69, 0.24);
 }
 
-.error {
-  color: #ffb3b3;
+.answer-tile.is-correct {
+  border-color: #79d78f;
+  background: rgba(57, 150, 80, 0.5);
 }
 
-.scoreboard ul {
-  list-style: none;
-  padding: 0;
-  margin: 0.5rem 0 0;
+.answer-tile.is-wrong {
+  border-color: #ef6f6f;
+  background: rgba(167, 43, 43, 0.5);
+}
+
+.answer-tile.is-revealed {
+  background: rgba(255, 236, 211, 0.17);
+}
+
+.action-bar {
   display: grid;
-  gap: 0.35rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin-top: 0.8rem;
 }
 
-.scoreboard li {
-  display: flex;
-  justify-content: space-between;
-  padding: 0.45rem 0.6rem;
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.06);
+.action-bar button:last-child:only-child {
+  grid-column: 1 / -1;
 }
 
-.scoreboard li.active-player {
-  border: 1px solid #69b8e6;
+.round-summary {
+  max-width: 560px;
+  margin: 0 auto;
+  padding: 1.25rem;
 }
 
-@media (max-width: 620px) {
-  .actions {
+@media (max-width: 980px) {
+  .game-board {
+    grid-template-columns: 1fr;
+  }
+
+  .players-panel {
+    order: 2;
+  }
+
+  .center-board {
+    order: 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .tile-grid,
+  .action-bar {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- add reusable board UI components: GameBoard, AnswerTile, PlayersPanel, RoundSummary
- update app screen composition to use the new layout shell
- restyle gameplay screen with Smart10-like orange board visual language and responsive structure

## How To Test
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run build
- run make dev and start a round to verify board layout, 10 tiles, action bar and player panel

## Screenshots / GIF
- CLI-only run in this environment, screenshot not captured in PR body.

Closes #44