### PR TITLE
feat(game): add explicit game phase state machine

### DIFF
--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -16,8 +16,10 @@ export default function GameBoard({
   card,
   selectedIndexes,
   toggleIndex,
-  revealed,
-  onReveal,
+  phase,
+  onAnswer,
+  onConfirm,
+  onCancelConfirm,
   onPass,
   onNext,
   isLast,
@@ -30,6 +32,9 @@ export default function GameBoard({
   lastAction,
   correctIndexes
 }) {
+  const revealed = phase === 'RESOLVED' || phase === 'PASSED';
+  const canChoose = phase === 'CHOOSING' || phase === 'CONFIRMING';
+
   return (
     <section className="game-board">
       <PlayersPanel
@@ -59,26 +64,47 @@ export default function GameBoard({
               option={option}
               state={getTileState(index, selectedIndexes, revealed, correctIndexes)}
               onClick={() => toggleIndex(index)}
-              disabled={revealed}
+              disabled={!canChoose}
             />
           ))}
         </div>
 
         <footer className="action-bar">
-          {!revealed ? (
+          {phase === 'CHOOSING' ? (
             <>
-              <button onClick={onReveal} type="button">
+              <button onClick={onAnswer} type="button">
                 ANSWER
               </button>
               <button onClick={onPass} type="button">
                 PASS
               </button>
             </>
-          ) : (
+          ) : null}
+          {phase === 'CONFIRMING' ? (
+            <>
+              <button onClick={onConfirm} type="button">
+                LOCK IN
+              </button>
+              <button onClick={onCancelConfirm} type="button">
+                BACK
+              </button>
+            </>
+          ) : null}
+          {phase === 'RESOLVED' || phase === 'PASSED' ? (
             <button onClick={onNext} type="button">
               {isLast ? 'ROUND END' : 'NEXT'}
             </button>
-          )}
+          ) : null}
+          {phase === 'LOADING_CARD' ? (
+            <button disabled type="button">
+              LOADING...
+            </button>
+          ) : null}
+          {phase !== 'CHOOSING' && phase !== 'CONFIRMING' && phase !== 'RESOLVED' && phase !== 'PASSED' && phase !== 'LOADING_CARD' ? (
+            <button disabled type="button">
+              WAITING...
+            </button>
+          ) : null}
         </footer>
       </div>
     </section>

--- a/frontend/src/state/scoring.ts
+++ b/frontend/src/state/scoring.ts
@@ -1,0 +1,30 @@
+export function expectedCorrectIndexes(card) {
+  if (!card) return new Set();
+
+  if (Array.isArray(card.correctFlags) && card.correctFlags.length === 10) {
+    return new Set(
+      card.correctFlags
+        .map((flag, idx) => (flag ? idx : null))
+        .filter((idx) => idx !== null)
+    );
+  }
+
+  if (Number.isInteger(card.correctIndex)) {
+    return new Set([card.correctIndex]);
+  }
+
+  return new Set();
+}
+
+function sameSet(a, b) {
+  if (a.size !== b.size) return false;
+  for (const item of a) {
+    if (!b.has(item)) return false;
+  }
+  return true;
+}
+
+export function scoreDelta(card, selectedIndexes, passed) {
+  if (passed) return 0;
+  return sameSet(expectedCorrectIndexes(card), selectedIndexes) ? 1 : 0;
+}

--- a/frontend/src/state/types.ts
+++ b/frontend/src/state/types.ts
@@ -1,0 +1,12 @@
+export const GamePhase = {
+  SETUP: 'SETUP',
+  LOADING_CARD: 'LOADING_CARD',
+  CHOOSING: 'CHOOSING',
+  CONFIRMING: 'CONFIRMING',
+  RESOLVED: 'RESOLVED',
+  PASSED: 'PASSED',
+  ROUND_SUMMARY: 'ROUND_SUMMARY'
+};
+
+export const DEFAULT_PLAYERS = ['Player 1'];
+export const DEFAULT_LANGS = ['en', 'et', 'ru'];

--- a/frontend/src/state/useGameEngine.ts
+++ b/frontend/src/state/useGameEngine.ts
@@ -1,0 +1,148 @@
+import { useCallback, useMemo, useState } from 'react';
+import { DEFAULT_PLAYERS, GamePhase } from './types';
+import { scoreDelta } from './scoring';
+
+function normalizePlayers(raw) {
+  const players = raw
+    .split(',')
+    .map((x) => x.trim())
+    .filter(Boolean);
+  return players.length > 0 ? players : DEFAULT_PLAYERS;
+}
+
+function initialScores(players) {
+  return players.reduce((acc, player) => {
+    acc[player] = 0;
+    return acc;
+  }, {});
+}
+
+export function useGameEngine(roundLength) {
+  const [phase, setPhase] = useState(GamePhase.SETUP);
+  const [players, setPlayers] = useState(DEFAULT_PLAYERS);
+  const [scores, setScores] = useState({ 'Player 1': 0 });
+  const [cardIndex, setCardIndex] = useState(0);
+  const [card, setCard] = useState(null);
+  const [selectedIndexes, setSelectedIndexes] = useState(new Set());
+  const [lastAction, setLastAction] = useState('Ready');
+
+  const currentPlayerIndex = useMemo(() => {
+    if (players.length === 0) return 0;
+    return cardIndex % players.length;
+  }, [cardIndex, players]);
+
+  const currentPlayer = players[currentPlayerIndex] ?? 'Player 1';
+
+  const startRound = useCallback((playersText) => {
+    const normalizedPlayers = normalizePlayers(playersText);
+    setPlayers(normalizedPlayers);
+    setScores(initialScores(normalizedPlayers));
+    setCardIndex(0);
+    setCard(null);
+    setSelectedIndexes(new Set());
+    setPhase(GamePhase.LOADING_CARD);
+    setLastAction('Round started');
+    return normalizedPlayers;
+  }, []);
+
+  const beginCardLoad = useCallback(() => {
+    setPhase(GamePhase.LOADING_CARD);
+    setCard(null);
+    setSelectedIndexes(new Set());
+    setLastAction('Loading card');
+  }, []);
+
+  const cardLoaded = useCallback((nextCard) => {
+    setCard(nextCard);
+    setSelectedIndexes(new Set());
+    setPhase(GamePhase.CHOOSING);
+    setLastAction('Card loaded');
+  }, []);
+
+  const cardLoadFailed = useCallback(() => {
+    setPhase(GamePhase.LOADING_CARD);
+    setCard(null);
+    setLastAction('Load failed');
+  }, []);
+
+  const toggleOption = useCallback((index) => {
+    if (phase !== GamePhase.CHOOSING && phase !== GamePhase.CONFIRMING) return;
+    setSelectedIndexes((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+    setPhase(GamePhase.CHOOSING);
+  }, [phase]);
+
+  const requestConfirm = useCallback(() => {
+    if (phase !== GamePhase.CHOOSING) return;
+    setPhase(GamePhase.CONFIRMING);
+  }, [phase]);
+
+  const cancelConfirm = useCallback(() => {
+    if (phase !== GamePhase.CONFIRMING) return;
+    setPhase(GamePhase.CHOOSING);
+  }, [phase]);
+
+  const confirmAnswer = useCallback(() => {
+    if (!card) return;
+    const delta = scoreDelta(card, selectedIndexes, false);
+    setScores((prev) => ({
+      ...prev,
+      [currentPlayer]: (prev[currentPlayer] ?? 0) + delta
+    }));
+    setPhase(GamePhase.RESOLVED);
+    setLastAction(`${currentPlayer} answered (${delta > 0 ? '+1' : '0'})`);
+  }, [card, currentPlayer, selectedIndexes]);
+
+  const passTurn = useCallback(() => {
+    setPhase(GamePhase.PASSED);
+    setLastAction(`${currentPlayer} passed`);
+  }, [currentPlayer]);
+
+  const nextStep = useCallback(() => {
+    const nextIndex = cardIndex + 1;
+    if (nextIndex >= roundLength) {
+      setPhase(GamePhase.ROUND_SUMMARY);
+      setLastAction('Round complete');
+      return { done: true };
+    }
+    setCardIndex(nextIndex);
+    setCard(null);
+    setSelectedIndexes(new Set());
+    setPhase(GamePhase.LOADING_CARD);
+    return { done: false };
+  }, [cardIndex, roundLength]);
+
+  const resetToSetup = useCallback(() => {
+    setPhase(GamePhase.SETUP);
+    setCard(null);
+    setSelectedIndexes(new Set());
+    setLastAction('Ready');
+  }, []);
+
+  return {
+    phase,
+    players,
+    scores,
+    cardIndex,
+    card,
+    selectedIndexes,
+    currentPlayerIndex,
+    currentPlayer,
+    lastAction,
+    startRound,
+    beginCardLoad,
+    cardLoaded,
+    cardLoadFailed,
+    toggleOption,
+    requestConfirm,
+    cancelConfirm,
+    confirmAnswer,
+    passTurn,
+    nextStep,
+    resetToSetup
+  };
+}


### PR DESCRIPTION
## Summary
- add GamePhase model (SETUP, LOADING_CARD, CHOOSING, CONFIRMING, RESOLVED, PASSED, ROUND_SUMMARY)
- add useGameEngine hook to manage transitions, turn progression, scores and round completion
- extract scoring logic to state/scoring.ts for future rule swaps
- wire board actions to state machine phases (ANSWER, LOCK IN, PASS, NEXT)

## How To Test
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run build
- run make dev and verify phase flow: setup -> choosing -> confirming -> resolved/passed -> next -> summary

## Screenshots / GIF
- CLI-only run in this environment, screenshot not captured in PR body.

Refs #44