### PR TITLE
feat(api): add /cards/next retries, fallback mode, and session persistence

### DIFF
--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,26 +1,89 @@
-const API_BASE =
+﻿const API_BASE =
   import.meta.env.VITE_API_BASE_URL ||
   import.meta.env.VITE_BACKEND_URL ||
   'http://localhost:8080';
 
-export async function fetchTopics() {
-  const res = await fetch(`${API_BASE}/api/topics`);
-  if (!res.ok) {
-    throw new Error(`Failed to fetch topics: ${res.status}`);
+class ApiError extends Error {
+  constructor(message, status, code) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
   }
-  return res.json();
 }
 
-export async function fetchNextCard({ topic, difficulty, sessionId, lang }) {
+async function delay(ms) {
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function fetchJson(url, { timeoutMs = 8000 } = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) {
+      throw new ApiError(`Request failed: ${res.status}`, res.status, 'HTTP_ERROR');
+    }
+    return res.json();
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      throw new ApiError('Request timed out', 0, 'TIMEOUT');
+    }
+    if (error instanceof ApiError) {
+      throw error;
+    }
+    throw new ApiError('Network request failed', 0, 'NETWORK_ERROR');
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function fetchTopics() {
+  return fetchJson(`${API_BASE}/api/topics`);
+}
+
+function isRetryable(error) {
+  if (!(error instanceof ApiError)) {
+    return true;
+  }
+  if (error.code === 'TIMEOUT' || error.code === 'NETWORK_ERROR') {
+    return true;
+  }
+  return error.status >= 500;
+}
+
+export async function fetchNextCard({ topic, difficulty, sessionId, lang, retries = 2 }) {
   const params = new URLSearchParams();
   if (topic) params.set('topic', topic);
   if (difficulty) params.set('difficulty', String(difficulty));
   if (sessionId) params.set('sessionId', sessionId);
   if (lang) params.set('lang', lang);
 
-  const res = await fetch(`${API_BASE}/api/cards/next?${params.toString()}`);
-  if (!res.ok) {
-    throw new Error(`Failed to fetch card: ${res.status}`);
+  const url = `${API_BASE}/api/cards/next?${params.toString()}`;
+
+  let lastError = null;
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await fetchJson(url);
+    } catch (error) {
+      lastError = error;
+      if (!isRetryable(error) || attempt === retries) {
+        throw error;
+      }
+      await delay(250 * (attempt + 1));
+    }
   }
-  return res.json();
+
+  throw lastError;
+}
+
+export function resolveCardErrorMessage(error) {
+  if (error instanceof ApiError && error.status === 404) {
+    return 'Question bank is empty for this filter. Run content pipeline in dev and import clean data.';
+  }
+
+  return 'Fallback mode: backend is unavailable right now. Retry to continue.';
 }

--- a/frontend/src/state/useGameEngine.ts
+++ b/frontend/src/state/useGameEngine.ts
@@ -25,6 +25,7 @@ export function useGameEngine(roundLength) {
   const [card, setCard] = useState(null);
   const [selectedIndexes, setSelectedIndexes] = useState(new Set());
   const [lastAction, setLastAction] = useState('Ready');
+  const [loadTicket, setLoadTicket] = useState(0);
 
   const currentPlayerIndex = useMemo(() => {
     if (players.length === 0) return 0;
@@ -41,6 +42,7 @@ export function useGameEngine(roundLength) {
     setCard(null);
     setSelectedIndexes(new Set());
     setPhase(GamePhase.LOADING_CARD);
+    setLoadTicket((value) => value + 1);
     setLastAction('Round started');
     return normalizedPlayers;
   }, []);
@@ -49,6 +51,7 @@ export function useGameEngine(roundLength) {
     setPhase(GamePhase.LOADING_CARD);
     setCard(null);
     setSelectedIndexes(new Set());
+    setLoadTicket((value) => value + 1);
     setLastAction('Loading card');
   }, []);
 
@@ -113,6 +116,7 @@ export function useGameEngine(roundLength) {
     setCard(null);
     setSelectedIndexes(new Set());
     setPhase(GamePhase.LOADING_CARD);
+    setLoadTicket((value) => value + 1);
     return { done: false };
   }, [cardIndex, roundLength]);
 
@@ -120,6 +124,7 @@ export function useGameEngine(roundLength) {
     setPhase(GamePhase.SETUP);
     setCard(null);
     setSelectedIndexes(new Set());
+    setLoadTicket(0);
     setLastAction('Ready');
   }, []);
 
@@ -129,6 +134,7 @@ export function useGameEngine(roundLength) {
     scores,
     cardIndex,
     card,
+    loadTicket,
     selectedIndexes,
     currentPlayerIndex,
     currentPlayer,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -82,6 +82,14 @@ button:disabled {
   color: #ffb4b4;
 }
 
+.error-panel {
+  margin: 0.7rem 0;
+  padding: 0.8rem;
+  border-radius: 12px;
+  border: 1px solid rgba(245, 122, 122, 0.45);
+  background: rgba(115, 34, 34, 0.45);
+}
+
 .game-board {
   display: grid;
   grid-template-columns: 280px 1fr;


### PR DESCRIPTION
## Summary
- harden frontend API client with timeout + retry logic for GET /api/cards/next
- add explicit fallback-mode and bank-empty error messages
- persist sessionId via localStorage and create fresh session at new round start
- keep client-side recent card id buffer to reduce accidental UI-level repeats
- add retry action in UI error state

## How To Test
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run build
- run make dev and verify retries/fallback message by stopping backend briefly, then Retry

## Screenshots / GIF
- CLI-only run in this environment, screenshot not captured in PR body.

Refs #44