### PR TITLE
docs(ui): document game board flow and state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ Endpoints:
 ## Game Flow v1
 
 - Start screen allows selecting `topic`, `difficulty` (1-3), `language`, round length, and player names.
-- Game screen fetches cards from `GET /api/cards/next` and renders 10 options.
-- Players can select multiple options, then use `Reveal / Check` or `Pass (keep points)`.
+- Game board fetches cards from `GET /api/cards/next` and renders 10 answer tiles.
+- Players use `ANSWER -> LOCK IN` or `PASS`, then continue with `NEXT`.
 - Round rotates turns by player and shows a summary after the configured card count.
+- Full UI/state-machine reference: `docs/ui.md`.
 
 ## Validation Commands
 
@@ -81,6 +82,13 @@ cd frontend
 npm ci
 npm run lint
 npm run build
+```
+
+Frontend tests:
+
+```bash
+cd frontend
+npm run test -- --run
 ```
 
 Data validation:

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,75 @@
+# UI and State Machine
+
+This document describes the SmartIQ frontend game UX and the state machine that powers the round flow.
+
+## Screens
+
+## Setup
+
+- Inputs: `topic`, `difficulty (1-3)`, `language`, round length, players list.
+- Action: `Start round`.
+- Behavior:
+  - Generates a session id (`crypto.randomUUID()` fallback to timestamp id).
+  - Resets local recent-card buffer.
+  - Moves to `LOADING_CARD`.
+
+## Play Board
+
+- Left panel:
+  - Player list with active player highlight.
+  - Score per player.
+  - Round status (`Card X / N`).
+  - Last action text.
+- Center panel:
+  - Card metadata (topic, difficulty, language).
+  - Question text.
+  - 10 answer tiles.
+  - Action bar (`ANSWER`, `PASS`, `LOCK IN`, `NEXT`) based on phase.
+
+## Round Summary
+
+- Sorted scoreboard.
+- `New round` button returns to setup.
+
+## GamePhase Model
+
+Defined in `frontend/src/state/types.ts`.
+
+- `SETUP`
+- `LOADING_CARD`
+- `CHOOSING`
+- `CONFIRMING`
+- `RESOLVED`
+- `PASSED`
+- `ROUND_SUMMARY`
+
+## Transition Rules
+
+- `SETUP -> LOADING_CARD` on start.
+- `LOADING_CARD -> CHOOSING` when card fetch succeeds.
+- `CHOOSING -> CONFIRMING` on `ANSWER`.
+- `CONFIRMING -> CHOOSING` on `BACK`.
+- `CONFIRMING -> RESOLVED` on `LOCK IN` (score applied).
+- `CHOOSING -> PASSED` on `PASS`.
+- `RESOLVED|PASSED -> LOADING_CARD` on `NEXT` while cards remain.
+- `RESOLVED|PASSED -> ROUND_SUMMARY` when round card limit reached.
+- `ROUND_SUMMARY -> SETUP` on `New round`.
+
+## API Integration
+
+- Preferred endpoint:
+  - `GET /api/cards/next?topic=&difficulty=&sessionId=&lang=`
+- Topics endpoint:
+  - `GET /api/topics`
+- Frontend behavior:
+  - Uses timeout + retry for transient/network errors.
+  - Shows fallback mode message on backend failures.
+  - Shows bank-empty guidance when backend returns `404`.
+  - Maintains local recent card id buffer (last 20 ids).
+
+## Test Coverage
+
+- State machine transitions:
+  - `frontend/src/state/useGameEngine.test.jsx`
+- Happy-path board flow:
+  - `frontend/src/App.test.jsx`


### PR DESCRIPTION
## Summary
- add docs/ui.md describing setup/play/summary screens and board behavior
- document full GamePhase transition rules and API integration behavior
- update README with current gameplay command flow and frontend test command

## How To Test
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run test -- --run
- 
pm --prefix frontend run build

## Screenshots / GIF
- CLI-only run in this environment, screenshot not captured in PR body.

Refs #44