### PR TITLE
chore(compound): document CI test gating + strictmode fix learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -143,3 +143,12 @@
   - Game-engine transitions and API fetch timing caused edge-case retries and one failing test assertion.
 - Preventive rule:
   - For multi-PR frontend flows, lock phase transitions first with hook tests, then layer API retries and UI integration tests.
+
+## 2026-02-18 - Loop 16 (PR68 Fix + CI Gate Merge)
+
+- Hard part:
+  - A blank frontend could pass lint/build while failing at runtime due to missing `React` symbol in `main.jsx`.
+- What broke:
+  - `React.StrictMode` rendered with `React is not defined` in browser console, causing an empty screen.
+- Preventive rule:
+  - Any entrypoint using `React.*` symbols must explicitly import `React`, and frontend CI must run tests in addition to lint/build before merge.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -39,3 +39,4 @@
 - For every new `@SpringBootTest`, define explicit H2 datasource properties in test-local config to avoid environment-leak failures.
 - For prod access-control filters, add tests that verify unauthenticated denial and authenticated success on protected endpoints.
 - For phased frontend rewrites, require one state-hook test suite and one UI happy-path test before merging integration/error-handling PRs.
+- If frontend entry code references `React.*` (for example `React.StrictMode`), explicitly import `React` in that file to avoid runtime blank-screen failures.


### PR DESCRIPTION
## Summary
- add Loop 16 lesson after PR #68 merge in docs/compound/lessons.md
- record prevention rule in docs/compound/rules.md for React.StrictMode entrypoint imports
- capture CI gating learning: frontend tests now mandatory in CI before merge

## Why
- mandatory post-merge compound update after merged PR

## Validation
- docs-only change; no runtime behavior change