### PR TITLE
feat(ui): radial wheel board with responsive fallback

### DIFF
--- a/frontend/src/components/GameBoard.test.jsx
+++ b/frontend/src/components/GameBoard.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen, within } from '@testing-library/react';
+import GameBoard from './GameBoard';
+
+function makeProps() {
+  return {
+    card: {
+      id: 'c1',
+      topic: 'Math',
+      difficulty: '2',
+      language: 'en',
+      question: 'Question?',
+      options: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J']
+    },
+    selectedIndexes: new Set(),
+    toggleIndex: vi.fn(),
+    phase: 'CHOOSING',
+    onAnswer: vi.fn(),
+    onConfirm: vi.fn(),
+    onCancelConfirm: vi.fn(),
+    onPass: vi.fn(),
+    onNext: vi.fn(),
+    isLast: false,
+    players: ['Player 1', 'Player 2'],
+    scores: { 'Player 1': 0, 'Player 2': 0 },
+    currentPlayerIndex: 0,
+    cardIndex: 0,
+    roundLength: 10,
+    passNote: 'Pass keeps score',
+    lastAction: 'Ready',
+    currentPlayer: 'Player 1',
+    correctIndexes: new Set([0])
+  };
+}
+
+describe('GameBoard layout', () => {
+  test('renders radial wheel layout by default', () => {
+    globalThis.__setResizeObserverWidth(1024);
+    render(<GameBoard {...makeProps()} />);
+
+    const wheel = screen.getByTestId('wheel-board');
+    expect(wheel).toBeInTheDocument();
+    expect(within(wheel).getAllByRole('button')).toHaveLength(10);
+  });
+
+  test('falls back to grid on narrow container', () => {
+    globalThis.__setResizeObserverWidth(640);
+    render(<GameBoard {...makeProps()} />);
+
+    expect(screen.getByTestId('fallback-grid')).toBeInTheDocument();
+    expect(screen.queryByTestId('wheel-board')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -167,10 +167,47 @@ button:disabled {
   margin-bottom: 0;
 }
 
+.answers-shell {
+  width: 100%;
+}
+
 .tile-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.55rem;
+}
+
+.wheel-board {
+  position: relative;
+  margin: 0 auto;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 202, 145, 0.3);
+  background: radial-gradient(circle, rgba(255, 216, 166, 0.08) 0%, rgba(25, 10, 3, 0.08) 62%, transparent 64%);
+}
+
+.wheel-hub {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 34%;
+  aspect-ratio: 1 / 1;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 1px solid rgba(255, 210, 165, 0.45);
+  background: rgba(52, 22, 8, 0.8);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  font-weight: 700;
+  color: #ffd9ad;
+  padding: 0.6rem;
+}
+
+.wheel-slot {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: clamp(160px, 22vw, 220px);
 }
 
 .answer-tile {
@@ -255,9 +292,36 @@ button:disabled {
   .center-board {
     order: 1;
   }
+
+  .wheel-slot {
+    width: clamp(140px, 34vw, 220px);
+  }
 }
 
 @media (max-width: 640px) {
+  .wheel-slot {
+    position: static;
+    width: auto;
+    transform: none;
+  }
+
+  .wheel-board {
+    width: 100% !important;
+    height: auto !important;
+    border: 0;
+    background: transparent;
+    border-radius: 0;
+  }
+
+  .wheel-hub {
+    position: static;
+    transform: none;
+    width: 100%;
+    aspect-ratio: auto;
+    border-radius: 12px;
+    margin-bottom: 0.6rem;
+  }
+
   .tile-grid,
   .action-bar {
     grid-template-columns: 1fr;

--- a/frontend/src/test/setupTests.js
+++ b/frontend/src/test/setupTests.js
@@ -1,1 +1,29 @@
 import '@testing-library/jest-dom/vitest';
+
+let resizeObserverWidth = 1024;
+
+globalThis.__setResizeObserverWidth = (width) => {
+  resizeObserverWidth = width;
+};
+
+class MockResizeObserver {
+  constructor(callback) {
+    this.callback = callback;
+  }
+
+  observe(target) {
+    this.callback([
+      {
+        target,
+        contentRect: {
+          width: resizeObserverWidth,
+          height: 720
+        }
+      }
+    ]);
+  }
+
+  disconnect() {}
+}
+
+globalThis.ResizeObserver = MockResizeObserver;


### PR DESCRIPTION
## Summary\n- replace answer grid rendering with radial wheel layout on desktop-sized containers\n- keep a responsive fallback grid for narrow widths (<720px)\n- keep existing AnswerTile behavior and game actions unchanged (layout-only PR)\n- add component tests for wheel mode and fallback mode using mocked ResizeObserver\n\n## Scope Safety\n- no gameplay/state-machine/scoring logic changed\n- no API contract changes\n\n## Validation\n- 
pm --prefix frontend run lint ✅\n- 
pm --prefix frontend run test -- --run ✅\n- 
pm --prefix frontend run build ✅\n- mvn -q -f backend/pom.xml test ✅\n- BACKEND_URL=http://localhost:8080 npm run smoke:test ⚠️ fails locally (/api/topics expected 200 got 500)\n