### PR TITLE
chore(compound): document wheel-board tradeoffs and test strategy

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -152,3 +152,12 @@
   - `React.StrictMode` rendered with `React is not defined` in browser console, causing an empty screen.
 - Preventive rule:
   - Any entrypoint using `React.*` symbols must explicitly import `React`, and frontend CI must run tests in addition to lint/build before merge.
+
+## 2026-02-18 - Loop 17 (PR70 Wheel Layout Merge)
+
+- Hard part:
+  - Delivering a large visual refactor while keeping behavior strictly unchanged required tighter scope boundaries than usual.
+- What broke:
+  - Initial wheel layout test used a fragile accessible-name selector and failed even though layout rendered correctly.
+- Preventive rule:
+  - For layout-only PRs, enforce robust structural tests (`data-testid` and container-scoped queries) and keep gameplay/state logic untouched.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -40,3 +40,4 @@
 - For prod access-control filters, add tests that verify unauthenticated denial and authenticated success on protected endpoints.
 - For phased frontend rewrites, require one state-hook test suite and one UI happy-path test before merging integration/error-handling PRs.
 - If frontend entry code references `React.*` (for example `React.StrictMode`), explicitly import `React` in that file to avoid runtime blank-screen failures.
+- For UI-only milestones, separate layout PRs from behavior PRs and verify scope by test coverage focused on structure rather than game rules.


### PR DESCRIPTION
## Summary
- add Loop 17 entry after PR #70 merge in docs/compound/lessons.md
- capture layout-only PR testing lesson (robust structural queries over fragile selectors)
- add compound rule to keep UI layout and behavior changes in separate PRs

## Why
- mandatory compound follow-up after merged PR #70

## Validation
- docs-only change; no runtime behavior change