### PR TITLE
chore(compound): document Smart10 round-flow testing rules

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -161,3 +161,12 @@
   - Initial wheel layout test used a fragile accessible-name selector and failed even though layout rendered correctly.
 - Preventive rule:
   - For layout-only PRs, enforce robust structural tests (`data-testid` and container-scoped queries) and keep gameplay/state logic untouched.
+
+## 2026-02-18 - Loop 18 (PR72 Smart10 Round Semantics Merge)
+
+- Hard part:
+  - Converting from multi-card rounds to one-card Smart10 rounds touched state transitions, turn rotation, and end-of-game flow at once.
+- What broke:
+  - Initial hook tests produced false negatives because multiple actions were executed in one `act`, masking phase-gated callbacks.
+- Preventive rule:
+  - For phase-gated hooks, execute one state transition per `act` in tests and assert round-end/win conditions explicitly (`pass`, `eliminate`, `target-score`).

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -41,3 +41,4 @@
 - For phased frontend rewrites, require one state-hook test suite and one UI happy-path test before merging integration/error-handling PRs.
 - If frontend entry code references `React.*` (for example `React.StrictMode`), explicitly import `React` in that file to avoid runtime blank-screen failures.
 - For UI-only milestones, separate layout PRs from behavior PRs and verify scope by test coverage focused on structure rather than game rules.
+- For turn-based game-engine changes, include tests for pass rotation, wrong-answer elimination, round-end condition, and target-score game-over before merge.


### PR DESCRIPTION
## Summary
- add Loop 18 entry in docs/compound/lessons.md for PR #72 behavior migration
- document testing pitfall with phase-gated hooks and ct batching
- add compound rule requiring pass/eliminate/round-end/game-over tests for turn-based engine changes

## Why
- mandatory compound follow-up after merged PR #72

## Validation
- docs-only change; no runtime behavior changes