### PR TITLE
fix(smoke): DB-aware health endpoint and resilient smoke retries

### DIFF
--- a/backend/src/main/java/com/smartiq/backend/web/HealthController.java
+++ b/backend/src/main/java/com/smartiq/backend/web/HealthController.java
@@ -1,5 +1,8 @@
 package com.smartiq.backend.web;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,8 +11,19 @@ import java.util.Map;
 @RestController
 public class HealthController {
 
+    private final JdbcTemplate jdbcTemplate;
+
+    public HealthController(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
     @GetMapping("/health")
-    public Map<String, String> health() {
-        return Map.of("status", "UP");
+    public ResponseEntity<Map<String, String>> health() {
+        try {
+            jdbcTemplate.queryForObject("select 1", Integer.class);
+            return ResponseEntity.ok(Map.of("status", "UP"));
+        } catch (Exception ex) {
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(Map.of("status", "DOWN"));
+        }
     }
 }

--- a/tools/smoke-test.js
+++ b/tools/smoke-test.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 const baseUrl = (process.env.BACKEND_URL || '').trim();
+const RETRY_ATTEMPTS = 5;
+const RETRY_DELAY_MS = 1500;
 
 function assert(condition, message) {
   if (!condition) {
@@ -7,16 +9,57 @@ function assert(condition, message) {
   }
 }
 
-async function getJson(url) {
-  const res = await fetch(url);
-  const text = await res.text();
-  let json = null;
+async function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function getJson(url, timeoutMs = 8000) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    json = text ? JSON.parse(text) : null;
-  } catch {
-    json = null;
+    const res = await fetch(url, { signal: controller.signal });
+    const text = await res.text();
+    let json = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      json = null;
+    }
+    return { status: res.status, json, text };
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw new Error(`Timeout while requesting ${url}`);
+    }
+    throw new Error(`Request failed for ${url}: ${error.message}`);
+  } finally {
+    clearTimeout(timeout);
   }
-  return { status: res.status, json, text };
+}
+
+function describeResponse(prefix, response) {
+  const body = response.text ? response.text.slice(0, 300) : '<empty>';
+  return `${prefix} (status=${response.status}, body=${body})`;
+}
+
+async function getJsonWithRetry(url) {
+  let lastResponse = null;
+  for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await getJson(url);
+      if (response.status >= 500 && attempt < RETRY_ATTEMPTS) {
+        await delay(RETRY_DELAY_MS);
+        lastResponse = response;
+        continue;
+      }
+      return response;
+    } catch (error) {
+      if (attempt === RETRY_ATTEMPTS) {
+        throw error;
+      }
+      await delay(RETRY_DELAY_MS);
+    }
+  }
+  return lastResponse;
 }
 
 function validateCard(card) {
@@ -34,15 +77,15 @@ async function main() {
     throw new Error('BACKEND_URL is required. Example: BACKEND_URL=https://smartiq-backend.onrender.com');
   }
 
-  const health = await getJson(`${baseUrl}/health`);
-  assert(health.status === 200, `/health expected 200 got ${health.status}`);
+  const health = await getJsonWithRetry(`${baseUrl}/health`);
+  assert(health.status === 200, describeResponse('/health expected 200', health));
 
-  const topics = await getJson(`${baseUrl}/api/topics`);
-  assert(topics.status === 200, `/api/topics expected 200 got ${topics.status}`);
+  const topics = await getJsonWithRetry(`${baseUrl}/api/topics`);
+  assert(topics.status === 200, describeResponse('/api/topics expected 200', topics));
   assert(Array.isArray(topics.json), '/api/topics must return array');
 
-  const card = await getJson(`${baseUrl}/api/cards/next?topic=Math&difficulty=2&sessionId=smoke&lang=en`);
-  assert(card.status === 200, `/api/cards/next expected 200 got ${card.status}`);
+  const card = await getJsonWithRetry(`${baseUrl}/api/cards/next?topic=Math&difficulty=2&sessionId=smoke&lang=en`);
+  assert(card.status === 200, describeResponse('/api/cards/next expected 200', card));
   validateCard(card.json);
 
   console.log(JSON.stringify({ ok: true, baseUrl }, null, 2));


### PR DESCRIPTION
## Summary
- make /health DB-aware by validating datasource with select 1
- return 503 with {status: DOWN} when DB is unavailable
- improve 	ools/smoke-test.js with retries, request timeouts, and richer error messages
- make smoke failures actionable (status + response snippet or timeout URL)

## Why
- root cause of flaky smoke runs was that /health always returned UP even when DB-backed endpoints like /api/topics were failing
- smoke test now distinguishes transient startup failures from persistent backend problems

## Validation
- mvn -q -f backend/pom.xml test ✅
- BACKEND_URL=http://localhost:8080 npm run smoke:test now fails with explicit timeout/details instead of opaque assertion crash when backend is unhealthy
