### PR TITLE
feat(backend): seed core data via Flyway repeatable migration

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -9,6 +9,8 @@ spring:
     open-in-view: false
   flyway:
     enabled: true
+    placeholders:
+      seed_core_enabled: true
   h2:
     console:
       enabled: true

--- a/backend/src/main/resources/db/migration/R__seed_core_data.sql
+++ b/backend/src/main/resources/db/migration/R__seed_core_data.sql
@@ -1,0 +1,92 @@
+-- Seed minimal core data for local/prod environments.
+-- This migration is idempotent and safe to re-run.
+
+insert into cards (id, topic, subtopic, language, question, correct_index, correct_flags, difficulty, source, created_at)
+with recursive seq(n) as (
+    select 1
+    union all
+    select n + 1 from seq where n < 20
+),
+topics(topic) as (
+    select 'Math'
+    union all select 'Science'
+    union all select 'History'
+    union all select 'Geography'
+    union all select 'Sports'
+    union all select 'Culture'
+),
+cards_seed(id, topic, subtopic, language, question, correct_index, correct_flags, difficulty, source, created_at) as (
+    select
+        lower(replace(topic, ' ', '-')) || '-seed-en-' || lpad(cast(n as varchar), 2, '0') as id,
+        topic,
+        cast(null as varchar) as subtopic,
+        'en' as language,
+        topic || ' sample question #' || cast(n as varchar) as question,
+        0 as correct_index,
+        cast(null as varchar) as correct_flags,
+        case
+            when mod(n, 3) = 1 then '1'
+            when mod(n, 3) = 2 then '2'
+            else '3'
+        end as difficulty,
+        'flyway-seed-core' as source,
+        current_timestamp as created_at
+    from topics
+    cross join seq
+)
+select
+    cs.id,
+    cs.topic,
+    cs.subtopic,
+    cs.language,
+    cs.question,
+    cs.correct_index,
+    cs.correct_flags,
+    cs.difficulty,
+    cs.source,
+    cs.created_at
+from cards_seed cs
+left join cards c on c.id = cs.id
+where lower('${seed_core_enabled}') = 'true'
+  and c.id is null;
+
+insert into card_options (card_id, option_index, option_text)
+with recursive seq(n) as (
+    select 1
+    union all
+    select n + 1 from seq where n < 20
+),
+opt(i) as (
+    select 0
+    union all
+    select i + 1 from opt where i < 9
+),
+topics(topic) as (
+    select 'Math'
+    union all select 'Science'
+    union all select 'History'
+    union all select 'Geography'
+    union all select 'Sports'
+    union all select 'Culture'
+),
+cards_seed(id, topic, n) as (
+    select
+        lower(replace(topic, ' ', '-')) || '-seed-en-' || lpad(cast(n as varchar), 2, '0') as id,
+        topic,
+        n
+    from topics
+    cross join seq
+)
+select
+    cs.id as card_id,
+    opt.i as option_index,
+    case
+        when opt.i = 0 then 'Correct answer for ' || cs.topic || ' #' || cast(cs.n as varchar)
+        else 'Option ' || cast(opt.i + 1 as varchar) || ' for ' || cs.topic || ' #' || cast(cs.n as varchar)
+    end as option_text
+from cards_seed cs
+cross join opt
+left join card_options existing
+       on existing.card_id = cs.id and existing.option_index = opt.i
+where lower('${seed_core_enabled}') = 'true'
+  and existing.card_id is null;

--- a/backend/src/test/java/com/smartiq/backend/card/GoldenDatasetImportTest.java
+++ b/backend/src/test/java/com/smartiq/backend/card/GoldenDatasetImportTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
         "smartiq.pool.enabled=false",
         "smartiq.session.enabled=false",
         "MIN_BANK_SIZE=1",
+        "spring.flyway.placeholders.seed_core_enabled=false",
         "spring.datasource.url=jdbc:h2:mem:smartiq_golden_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
         "spring.datasource.username=sa",
         "spring.datasource.password="

--- a/backend/src/test/java/com/smartiq/backend/card/SeedDataMigrationTest.java
+++ b/backend/src/test/java/com/smartiq/backend/card/SeedDataMigrationTest.java
@@ -1,0 +1,37 @@
+package com.smartiq.backend.card;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "smartiq.import.enabled=false",
+        "smartiq.pool.enabled=false",
+        "smartiq.session.enabled=false",
+        "spring.datasource.url=jdbc:h2:mem:smartiq_seed_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password="
+})
+@AutoConfigureMockMvc
+class SeedDataMigrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void topicsEndpointReturnsSeededTopics() throws Exception {
+        mockMvc.perform(get("/api/topics"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(greaterThanOrEqualTo(6)))
+                .andExpect(jsonPath("$[*].topic").value(hasItem("Math")))
+                .andExpect(jsonPath("$[?(@.topic=='Math')].count").value(hasItem(20)));
+    }
+}

--- a/backend/src/test/java/com/smartiq/backend/web/InternalAccessFilterTest.java
+++ b/backend/src/test/java/com/smartiq/backend/web/InternalAccessFilterTest.java
@@ -14,8 +14,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "smartiq.import.enabled=false",
         "smartiq.pool.enabled=false",
         "smartiq.session.enabled=false",
+        "smartiq.bank.block-on-low-bank=false",
         "smartiq.internal-access.enabled=true",
         "smartiq.internal-access.api-key=test-internal-key",
+        "spring.flyway.placeholders.seed_core_enabled=false",
         "spring.datasource.url=jdbc:h2:mem:smartiq_internal_access_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
         "spring.datasource.username=sa",
         "spring.datasource.password="


### PR DESCRIPTION
## Summary\n- add R__seed_core_data.sql to seed 6 topics with 20 cards/topic and 10 options/card\n- keep seed idempotent by inserting only missing card and card_option rows\n- wire Flyway placeholder seed_core_enabled (default true)\n- add SeedDataMigrationTest to assert /api/topics is non-empty and seeded\n- keep golden/internal tests deterministic with explicit placeholder/prod overrides\n\n## Why\nRender prod had empty DB, so /api/topics returned an empty list. This seed ensures baseline playable content exists without relying on external import path presence.\n\n## Checks\n- mvn -q -f backend/pom.xml test\n- 
pm --prefix frontend run lint\n- 
pm --prefix frontend run test -- --run\n- 
pm --prefix frontend run build\n\n## How to test\n1. Start backend with empty DB and Flyway enabled\n2. GET /api/topics should return at least 6 topics\n3. GET /api/cards/next?topic=Math&difficulty=1&sessionId=smoke&lang=en should return a card\n\n## Risk\n- Seed data is synthetic baseline content for availability, not final curated question quality.\n