### PR TITLE
feat(api): cards/next filtering contract with topicId + defaults

### DIFF
--- a/backend/src/main/java/com/smartiq/backend/card/CardResponse.java
+++ b/backend/src/main/java/com/smartiq/backend/card/CardResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 public record CardResponse(
         String id,
+        String cardId,
         String topic,
         String subtopic,
         String language,
@@ -17,6 +18,7 @@ public record CardResponse(
 ) {
     static CardResponse fromEntity(Card card) {
         return new CardResponse(
+                card.getId(),
                 card.getId(),
                 card.getTopic(),
                 card.getSubtopic(),


### PR DESCRIPTION
## Summary\n- update GET /api/cards/next to accept 	opicId (preferred) with legacy 	opic fallback\n- require topic presence (returns 400 when missing)\n- set defaults: difficulty=1, lang=en\n- keep empty-result behavior as 404 for unknown filter combinations\n- include cardId in response payload while preserving existing id\n\n## Tests\n- extended CardControllerTest coverage for:\n  - topicId filtering\n  - default difficulty/lang behavior\n  - 400 for missing topic\n  - 404 for no cards\n\n## Checks\n- mvn -q -f backend/pom.xml clean test\n- 
pm --prefix frontend run lint\n- 
pm --prefix frontend run test -- --run\n- 
pm --prefix frontend run build\n\n## Risk\n- API now validates missing topic strictly on /api/cards/next; legacy callers must provide 	opic or 	opicId.\n