### PR TITLE
feat(api): standardized JSON error contract + request validation

### DIFF
--- a/backend/src/main/java/com/smartiq/backend/card/CardController.java
+++ b/backend/src/main/java/com/smartiq/backend/card/CardController.java
@@ -1,16 +1,15 @@
 package com.smartiq.backend.card;
 
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import jakarta.validation.constraints.Pattern;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
-import java.util.Map;
-import java.util.NoSuchElementException;
 
+@Validated
 @RestController
 @RequestMapping("/api")
 public class CardController {
@@ -27,23 +26,19 @@ public class CardController {
     }
 
     @GetMapping("/cards/random")
-    public ResponseEntity<?> getRandomCard(@RequestParam(name = "topic", required = false) String topic) {
-        try {
-            return ResponseEntity.ok(cardService.getRandomCard(topic));
-        } catch (NoSuchElementException ex) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", ex.getMessage()));
-        }
+    public CardResponse getRandomCard(@RequestParam(name = "topic", required = false) String topic) {
+        return cardService.getRandomCard(topic);
     }
 
     @GetMapping("/cards/next")
-    public ResponseEntity<?> getNextCard(@RequestParam(name = "topic", required = false) String topic,
-                                         @RequestParam(name = "difficulty", required = false) String difficulty,
+    public CardResponse getNextCard(@RequestParam(name = "topic", required = false) String topic,
+                                         @RequestParam(name = "difficulty", required = false)
+                                         @Pattern(regexp = "^(?:[1-3]|easy|medium|hard)$", message = "difficulty must be 1-3 or easy/medium/hard")
+                                         String difficulty,
                                          @RequestParam(name = "sessionId", required = false) String sessionId,
-                                         @RequestParam(name = "lang", required = false) String language) {
-        try {
-            return ResponseEntity.ok(cardService.getNextCard(topic, difficulty, sessionId, language));
-        } catch (NoSuchElementException ex) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", ex.getMessage()));
-        }
+                                         @RequestParam(name = "lang", required = false)
+                                         @Pattern(regexp = "^[a-z]{2}$", message = "lang must be two lowercase letters")
+                                         String language) {
+        return cardService.getNextCard(topic, difficulty, sessionId, language);
     }
 }

--- a/backend/src/main/java/com/smartiq/backend/web/ApiErrorResponse.java
+++ b/backend/src/main/java/com/smartiq/backend/web/ApiErrorResponse.java
@@ -1,0 +1,12 @@
+package com.smartiq.backend.web;
+
+import java.time.Instant;
+
+public record ApiErrorResponse(
+        Instant timestamp,
+        int status,
+        String error,
+        String message,
+        String path
+) {
+}

--- a/backend/src/main/java/com/smartiq/backend/web/ApiExceptionHandler.java
+++ b/backend/src/main/java/com/smartiq/backend/web/ApiExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.smartiq.backend.web;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.Instant;
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler({
+            IllegalArgumentException.class,
+            ConstraintViolationException.class,
+            MissingServletRequestParameterException.class,
+            MethodArgumentTypeMismatchException.class
+    })
+    public ResponseEntity<ApiErrorResponse> handleBadRequest(Exception ex, HttpServletRequest request) {
+        return build(HttpStatus.BAD_REQUEST, ex.getMessage(), request.getRequestURI());
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ApiErrorResponse> handleNotFound(NoSuchElementException ex, HttpServletRequest request) {
+        return build(HttpStatus.NOT_FOUND, ex.getMessage(), request.getRequestURI());
+    }
+
+    private ResponseEntity<ApiErrorResponse> build(HttpStatus status, String message, String path) {
+        return ResponseEntity.status(status).body(new ApiErrorResponse(
+                Instant.now(),
+                status.value(),
+                status.getReasonPhrase(),
+                message,
+                path
+        ));
+    }
+}

--- a/backend/src/test/java/com/smartiq/backend/card/CardControllerTest.java
+++ b/backend/src/test/java/com/smartiq/backend/card/CardControllerTest.java
@@ -105,7 +105,10 @@ class CardControllerTest {
     void returnsNotFoundForMissingTopic() throws Exception {
         mockMvc.perform(get("/api/cards/random").param("topic", "Unknown"))
                 .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.error").exists());
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.error").value("Not Found"))
+                .andExpect(jsonPath("$.path").value("/api/cards/random"))
+                .andExpect(jsonPath("$.message").exists());
     }
 
     @Test
@@ -118,6 +121,20 @@ class CardControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.topic").value("Math"))
                 .andExpect(jsonPath("$.difficulty").value("2"));
+    }
+
+    @Test
+    void returnsBadRequestForInvalidDifficulty() throws Exception {
+        mockMvc.perform(get("/api/cards/next")
+                        .param("topic", "Math")
+                        .param("difficulty", "invalid")
+                        .param("sessionId", "test-session")
+                        .param("lang", "en"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.error").value("Bad Request"))
+                .andExpect(jsonPath("$.path").value("/api/cards/next"))
+                .andExpect(jsonPath("$.message").exists());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add ApiExceptionHandler with consistent API error payloads
- add ApiErrorResponse fields: timestamp, status, error, message, path
- use exception-driven handling in /api/cards/random and /api/cards/next
- add request param validation for difficulty and lang in /api/cards/next

## Tests
- update CardControllerTest assertions for 404 payload shape
- add 400 validation test for invalid difficulty

## Checks
- mvn -q -f backend/pom.xml clean test
- npm --prefix frontend run lint
- npm --prefix frontend run test -- --run
- npm --prefix frontend run build

## Risk
- error JSON shape for controller-thrown errors is now structured instead of a plain error field.