### PR TITLE
feat(backend): add basic per-IP rate limiting for cards-next

### DIFF
--- a/backend/src/main/java/com/smartiq/backend/config/ImportConfiguration.java
+++ b/backend/src/main/java/com/smartiq/backend/config/ImportConfiguration.java
@@ -10,7 +10,8 @@ import org.springframework.context.annotation.Configuration;
         SessionDedupProperties.class,
         CorsProperties.class,
         BankEnforcerProperties.class,
-        InternalAccessProperties.class
+        InternalAccessProperties.class,
+        RateLimitProperties.class
 })
 public class ImportConfiguration {
 }

--- a/backend/src/main/java/com/smartiq/backend/config/RateLimitProperties.java
+++ b/backend/src/main/java/com/smartiq/backend/config/RateLimitProperties.java
@@ -1,0 +1,12 @@
+package com.smartiq.backend.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "smartiq.rate-limit")
+public record RateLimitProperties(
+        boolean enabled,
+        int windowSeconds,
+        int cardsNextPerMinute,
+        int sessionAnswerPerMinute
+) {
+}

--- a/backend/src/main/java/com/smartiq/backend/web/RateLimitFilter.java
+++ b/backend/src/main/java/com/smartiq/backend/web/RateLimitFilter.java
@@ -1,0 +1,91 @@
+package com.smartiq.backend.web;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.smartiq.backend.config.RateLimitProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final RateLimitProperties properties;
+    private final ObjectMapper objectMapper;
+    private final ConcurrentHashMap<String, CounterWindow> counters = new ConcurrentHashMap<>();
+
+    public RateLimitFilter(RateLimitProperties properties, ObjectMapper objectMapper) {
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        if (!properties.enabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        int limit = resolveLimit(request.getRequestURI());
+        if (limit <= 0) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String key = request.getRequestURI() + "|" + clientIp(request);
+        long nowSeconds = Instant.now().getEpochSecond();
+        CounterWindow window = counters.compute(key, (ignored, current) -> refreshWindow(current, nowSeconds));
+
+        if (window.count() > limit) {
+            response.setStatus(429);
+            response.setHeader("Retry-After", String.valueOf(Math.max(1, window.windowStart() + properties.windowSeconds() - nowSeconds)));
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            objectMapper.writeValue(response.getWriter(), Map.of(
+                    "status", 429,
+                    "error", "Too Many Requests",
+                    "message", "Rate limit exceeded for " + request.getRequestURI()
+            ));
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private int resolveLimit(String uri) {
+        if ("/api/cards/next".equals(uri)) {
+            return properties.cardsNextPerMinute();
+        }
+        if ("/api/session/answer".equals(uri)) {
+            return properties.sessionAnswerPerMinute();
+        }
+        return -1;
+    }
+
+    private CounterWindow refreshWindow(CounterWindow current, long nowSeconds) {
+        if (current == null || nowSeconds - current.windowStart() >= properties.windowSeconds()) {
+            return new CounterWindow(nowSeconds, 1);
+        }
+        return new CounterWindow(current.windowStart(), current.count() + 1);
+    }
+
+    private static String clientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader("X-Forwarded-For");
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+
+    private record CounterWindow(long windowStart, int count) {
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -60,3 +60,8 @@ smartiq:
       - /actuator/env
       - /actuator/configprops
       - /actuator/beans
+  rate-limit:
+    enabled: ${SMARTIQ_RATE_LIMIT_ENABLED:true}
+    window-seconds: ${SMARTIQ_RATE_LIMIT_WINDOW_SECONDS:60}
+    cards-next-per-minute: ${SMARTIQ_RATE_LIMIT_CARDS_NEXT_PER_MINUTE:120}
+    session-answer-per-minute: ${SMARTIQ_RATE_LIMIT_SESSION_ANSWER_PER_MINUTE:180}

--- a/backend/src/test/java/com/smartiq/backend/web/RateLimitFilterTest.java
+++ b/backend/src/test/java/com/smartiq/backend/web/RateLimitFilterTest.java
@@ -1,0 +1,81 @@
+package com.smartiq.backend.web;
+
+import com.smartiq.backend.card.Card;
+import com.smartiq.backend.card.CardRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "smartiq.import.enabled=false",
+        "smartiq.pool.enabled=false",
+        "smartiq.session.enabled=false",
+        "smartiq.rate-limit.enabled=true",
+        "smartiq.rate-limit.window-seconds=60",
+        "smartiq.rate-limit.cards-next-per-minute=2",
+        "smartiq.rate-limit.session-answer-per-minute=2",
+        "spring.datasource.url=jdbc:h2:mem:smartiq_rate_limit_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password="
+})
+@AutoConfigureMockMvc
+class RateLimitFilterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private CardRepository cardRepository;
+
+    @BeforeEach
+    void setUp() {
+        cardRepository.deleteAll();
+        Card card = new Card();
+        card.setId("math-rate-limit");
+        card.setTopic("Math");
+        card.setSubtopic("General");
+        card.setLanguage("en");
+        card.setQuestion("Rate limit test question");
+        card.setOptions(List.of("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"));
+        card.setCorrectIndex(0);
+        card.setDifficulty("1");
+        card.setSource("test");
+        card.setCreatedAt(Instant.parse("2026-02-17T00:00:00Z"));
+        cardRepository.save(card);
+    }
+
+    @Test
+    void returns429WhenCardsNextLimitExceeded() throws Exception {
+        mockMvc.perform(get("/api/cards/next")
+                        .param("topic", "Math")
+                        .param("difficulty", "1")
+                        .param("sessionId", "s1")
+                        .param("lang", "en"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/cards/next")
+                        .param("topic", "Math")
+                        .param("difficulty", "1")
+                        .param("sessionId", "s2")
+                        .param("lang", "en"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/cards/next")
+                        .param("topic", "Math")
+                        .param("difficulty", "1")
+                        .param("sessionId", "s3")
+                        .param("lang", "en"))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(header().exists("Retry-After"));
+    }
+}


### PR DESCRIPTION
## Summary
- add RateLimitFilter for per-IP request limiting
- protect GET /api/cards/next and POST /api/session/answer paths
- return 429 with Retry-After header when limit is exceeded
- add configurable limits in smartiq.rate-limit.* properties
- add RateLimitFilterTest validating 429 behavior

## Defaults
- smartiq.rate-limit.enabled=true
- smartiq.rate-limit.window-seconds=60
- smartiq.rate-limit.cards-next-per-minute=120
- smartiq.rate-limit.session-answer-per-minute=180

## Checks
- mvn -q -f backend/pom.xml clean test
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run test -- --run
- 
pm --prefix frontend run build

## Risk
- Shared IPs can hit limits earlier in some network setups; values are configurable by env.