### PR TITLE
feat(backend): add correlation-id filter and structured API logs

### DIFF
--- a/backend/src/main/java/com/smartiq/backend/card/CardController.java
+++ b/backend/src/main/java/com/smartiq/backend/card/CardController.java
@@ -6,6 +6,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -14,6 +16,7 @@ import java.util.NoSuchElementException;
 @RestController
 @RequestMapping("/api")
 public class CardController {
+    private static final Logger log = LoggerFactory.getLogger(CardController.class);
 
     private final CardService cardService;
 
@@ -23,11 +26,13 @@ public class CardController {
 
     @GetMapping("/topics")
     public List<TopicCountResponse> getTopics() {
+        log.info("api_topics_fetch");
         return cardService.getTopicCounts();
     }
 
     @GetMapping("/cards/random")
     public ResponseEntity<?> getRandomCard(@RequestParam(name = "topic", required = false) String topic) {
+        log.info("api_card_random topic={}", topic == null ? "any" : topic);
         try {
             return ResponseEntity.ok(cardService.getRandomCard(topic));
         } catch (NoSuchElementException ex) {
@@ -40,6 +45,11 @@ public class CardController {
                                          @RequestParam(name = "difficulty", required = false) String difficulty,
                                          @RequestParam(name = "sessionId", required = false) String sessionId,
                                          @RequestParam(name = "lang", required = false) String language) {
+        log.info("api_card_next topic={} difficulty={} lang={} hasSession={}",
+                topic == null ? "any" : topic,
+                difficulty == null ? "any" : difficulty,
+                language == null ? "any" : language,
+                sessionId != null && !sessionId.isBlank());
         try {
             return ResponseEntity.ok(cardService.getNextCard(topic, difficulty, sessionId, language));
         } catch (NoSuchElementException ex) {

--- a/backend/src/main/java/com/smartiq/backend/web/CorrelationIdFilter.java
+++ b/backend/src/main/java/com/smartiq/backend/web/CorrelationIdFilter.java
@@ -1,0 +1,41 @@
+package com.smartiq.backend.web;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class CorrelationIdFilter extends OncePerRequestFilter {
+
+    public static final String HEADER_NAME = "X-Correlation-Id";
+    private static final String MDC_KEY = "correlationId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String correlationId = resolveCorrelationId(request.getHeader(HEADER_NAME));
+        MDC.put(MDC_KEY, correlationId);
+        response.setHeader(HEADER_NAME, correlationId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(MDC_KEY);
+        }
+    }
+
+    private static String resolveCorrelationId(String incomingHeader) {
+        if (incomingHeader != null && !incomingHeader.isBlank()) {
+            return incomingHeader.trim();
+        }
+        return UUID.randomUUID().toString();
+    }
+}

--- a/backend/src/test/java/com/smartiq/backend/web/CorrelationIdFilterTest.java
+++ b/backend/src/test/java/com/smartiq/backend/web/CorrelationIdFilterTest.java
@@ -1,0 +1,40 @@
+package com.smartiq.backend.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "smartiq.import.enabled=false",
+        "smartiq.pool.enabled=false",
+        "smartiq.session.enabled=false",
+        "spring.datasource.url=jdbc:h2:mem:smartiq_correlation_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password="
+})
+@AutoConfigureMockMvc
+class CorrelationIdFilterTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void generatesCorrelationIdWhenMissing() throws Exception {
+        mockMvc.perform(get("/health"))
+                .andExpect(status().isOk())
+                .andExpect(header().exists(CorrelationIdFilter.HEADER_NAME));
+    }
+
+    @Test
+    void echoesIncomingCorrelationId() throws Exception {
+        mockMvc.perform(get("/health").header(CorrelationIdFilter.HEADER_NAME, "cid-test-123"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(CorrelationIdFilter.HEADER_NAME, "cid-test-123"));
+    }
+}


### PR DESCRIPTION
## Summary
- add CorrelationIdFilter to propagate X-Correlation-Id
- generate correlation id when missing and echo in response header
- bind correlation id to MDC for log enrichment
- add structured endpoint logs for /api/topics, /api/cards/random, /api/cards/next
- add CorrelationIdFilterTest for header generation/echo behavior

## Checks
- mvn -q -f backend/pom.xml clean test
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run test -- --run
- 
pm --prefix frontend run build

## Risk
- Log volume slightly increases for card endpoints; messages are concise and avoid sensitive payload data.