### PR TITLE
chore(compound): document flyway seed migration lessons

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -170,3 +170,12 @@
   - Initial hook tests produced false negatives because multiple actions were executed in one `act`, masking phase-gated callbacks.
 - Preventive rule:
   - For phase-gated hooks, execute one state transition per `act` in tests and assert round-end/win conditions explicitly (`pass`, `eliminate`, `target-score`).
+
+## 2026-02-18 - Loop 19 (PR77 Flyway Seed Data Merge)
+
+- Hard part:
+  - Keeping repeatable seed SQL compatible across PostgreSQL production and H2 test runtime.
+- What broke:
+  - Initial migration CTE syntax passed on PostgreSQL style assumptions but failed under H2 parsing in CI tests.
+- Preventive rule:
+  - Validate new Flyway SQL with `mvn clean test` early, and use portable `INSERT ... WITH RECURSIVE ... SELECT` statements for cross-database test compatibility.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -42,3 +42,4 @@
 - If frontend entry code references `React.*` (for example `React.StrictMode`), explicitly import `React` in that file to avoid runtime blank-screen failures.
 - For UI-only milestones, separate layout PRs from behavior PRs and verify scope by test coverage focused on structure rather than game rules.
 - For turn-based game-engine changes, include tests for pass rotation, wrong-answer elimination, round-end condition, and target-score game-over before merge.
+- For Flyway migrations that must run in both prod and tests, prefer SQL constructs proven in both Postgres and H2, and always verify with `mvn clean test` before opening PR.


### PR DESCRIPTION
## Summary
- update docs/compound/lessons.md with Loop 19 for merged PR #77
- update docs/compound/rules.md with Flyway cross-DB migration safety rule

## Why
Mandatory compound update after merge to preserve loop learnings and prevent repeated migration breakages.