### PR TITLE
fix(frontend): lock Vite dev server to port 5173

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173
+    port: 5173,
+    strictPort: true
   }
 });


### PR DESCRIPTION
## Summary
- lock Vite dev server to port 5173 with strictPort=true
- prevent automatic fallback to 5174/5175 that caused local CORS mismatches

## How to test
- npm --prefix frontend run lint
- npm --prefix frontend run build
- npm --prefix frontend run dev (should use 5173, fail fast if occupied)

## Notes
- no backend/security/cors code changes in this PR