### PR TITLE
fix(frontend): startup resilience states + actionable recovery UI

### DIFF
--- a/frontend/src/App.startup.test.jsx
+++ b/frontend/src/App.startup.test.jsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import App from './App';
+
+vi.mock('./api', () => {
+  return {
+    API_BASE: 'http://localhost:8080',
+    fetchTopics: vi.fn(),
+    fetchNextCard: vi.fn(),
+    resolveCardErrorMessage: vi.fn(() => 'Fallback mode'),
+    resolveTopicsErrorState: vi.fn(() => ({
+      title: 'Backend is unreachable.',
+      detail: 'Verify backend URL and that the API server is running.',
+      kind: 'backend-unreachable'
+    }))
+  };
+});
+
+import { fetchTopics } from './api';
+
+describe('App startup resilience', () => {
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test('shows loading state before topics resolve', () => {
+    fetchTopics.mockImplementation(() => new Promise(() => {}));
+
+    render(<App />);
+
+    expect(screen.getByText(/loading topics/i)).toBeInTheDocument();
+  });
+
+  test('shows actionable backend error with retry', async () => {
+    fetchTopics.mockRejectedValue(new Error('network'));
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/backend is unreachable/i)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    expect(screen.getByText(/check backend url/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /open health/i })).toBeInTheDocument();
+  });
+
+  test('shows empty topics state', async () => {
+    fetchTopics.mockResolvedValue([]);
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText(/no topics available/i)).toBeInTheDocument());
+  });
+
+  test('renders setup screen when topics are available', async () => {
+    fetchTopics.mockResolvedValue([{ topic: 'Math', count: 20 }]);
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /start game/i })).toBeInTheDocument());
+    expect(screen.getByLabelText(/topic/i)).toBeInTheDocument();
+  });
+
+  test('retry button re-requests topics', async () => {
+    fetchTopics
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce([{ topic: 'Science', count: 20 }]);
+
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /start game/i })).toBeInTheDocument());
+  });
+});

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -3,9 +3,15 @@ import App from './App';
 
 vi.mock('./api', () => {
   return {
+    API_BASE: 'http://localhost:8080',
     fetchTopics: vi.fn(),
     fetchNextCard: vi.fn(),
-    resolveCardErrorMessage: vi.fn(() => 'Fallback mode')
+    resolveCardErrorMessage: vi.fn(() => 'Fallback mode'),
+    resolveTopicsErrorState: vi.fn(() => ({
+      title: 'Could not load topics.',
+      detail: 'Unexpected backend response.',
+      kind: 'backend-unreachable'
+    }))
   };
 });
 
@@ -24,6 +30,11 @@ function makeCard(id, correctIndex = 0) {
 }
 
 describe('App Smart10 round flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
   test('plays one-card round and advances to next round', async () => {
     fetchTopics.mockResolvedValue([{ topic: 'Math', count: 20 }]);
     fetchNextCard

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,4 +1,4 @@
-﻿const API_BASE =
+export const API_BASE =
   import.meta.env.VITE_API_BASE_URL ||
   import.meta.env.VITE_BACKEND_URL ||
   'http://localhost:8080';
@@ -43,6 +43,38 @@ async function fetchJson(url, { timeoutMs = 8000 } = {}) {
 
 export async function fetchTopics() {
   return fetchJson(`${API_BASE}/api/topics`);
+}
+
+export function resolveTopicsErrorState(error) {
+  if (error?.code === 'TIMEOUT') {
+    return {
+      title: 'Backend request timed out.',
+      detail: 'Check if backend is running, then retry.',
+      kind: 'backend-unreachable'
+    };
+  }
+
+  if (error?.code === 'NETWORK_ERROR') {
+    return {
+      title: 'Backend is unreachable.',
+      detail: 'Verify backend URL and that the API server is running.',
+      kind: 'backend-unreachable'
+    };
+  }
+
+  if (error?.status === 403) {
+    return {
+      title: 'API call was blocked (403).',
+      detail: 'Check CORS allowed origins and frontend URL.',
+      kind: 'backend-unreachable'
+    };
+  }
+
+  return {
+    title: 'Could not load topics.',
+    detail: 'Unexpected backend response. Retry and inspect backend logs.',
+    kind: 'backend-unreachable'
+  };
 }
 
 function isRetryable(error) {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -38,6 +38,10 @@ main {
   gap: 0.25rem;
 }
 
+.startup-panel {
+  gap: 0.5rem;
+}
+
 h1,
 h2,
 h3,
@@ -97,6 +101,20 @@ button:disabled {
   border-radius: 12px;
   border: 1px solid rgba(245, 122, 122, 0.45);
   background: rgba(115, 34, 34, 0.45);
+}
+
+.startup-hint {
+  color: #ffdcb7;
+  margin: 0;
+}
+
+.startup-hint code {
+  color: #ffeed8;
+}
+
+.inline-link {
+  color: #ffd7a9;
+  font-weight: 700;
 }
 
 .game-board {


### PR DESCRIPTION
## Summary
- replace opaque setup boot handling with explicit startup phases: loading, backend-unreachable, topics-empty, ready
- add actionable recovery UI on setup errors: retry button, backend URL hint, health endpoint link
- classify topic load failures in pi.js for clearer user-facing messaging
- add RTL coverage for startup states and retry behavior

## Scope
- frontend-only
- no gameplay rule changes
- no backend/security/cors changes

## How to test
- npm --prefix frontend run lint
- npm --prefix frontend run test -- --run
- npm --prefix frontend run build
- mvn -q -f backend/pom.xml test

## Acceptance check
- user never sees an unexplained blank setup screen
- setup shows actionable guidance when topics cannot load

Closes #84