### PR TITLE
chore(compound): document startup resilience loop learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -179,3 +179,12 @@
   - Initial migration CTE syntax passed on PostgreSQL style assumptions but failed under H2 parsing in CI tests.
 - Preventive rule:
   - Validate new Flyway SQL with `mvn clean test` early, and use portable `INSERT ... WITH RECURSIVE ... SELECT` statements for cross-database test compatibility.
+
+## 2026-02-18 - Loop 20 (PR85 Frontend Startup Resilience Merge)
+
+- Hard part:
+  - Converting a generic topic-load failure into deterministic startup states without touching gameplay flow.
+- What broke:
+  - Users saw an opaque dark screen state with only a generic message, making backend/CORS/runtime diagnosis too slow.
+- Preventive rule:
+  - Frontend setup boot must expose explicit `loading`, `backend-unreachable`, `topics-empty`, and `ready` states with retry + health-link actions.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -43,3 +43,4 @@
 - For UI-only milestones, separate layout PRs from behavior PRs and verify scope by test coverage focused on structure rather than game rules.
 - For turn-based game-engine changes, include tests for pass rotation, wrong-answer elimination, round-end condition, and target-score game-over before merge.
 - For Flyway migrations that must run in both prod and tests, prefer SQL constructs proven in both Postgres and H2, and always verify with `mvn clean test` before opening PR.
+- For frontend boot/setup flow, require explicit startup-state tests for `loading`, `backend-unreachable`, `topics-empty`, and `ready` before merge.


### PR DESCRIPTION
## Summary
- add Loop 20 lesson entry for merged startup resilience PR (#85)
- add compound rule requiring explicit frontend startup-state tests (loading, ackend-unreachable, 	opics-empty, eady)

## Why
- mandatory post-merge compound update per workflow policy

Closes #86