### PR TITLE
feat(game): Smart10 core-flow guards and round-reset correctness

### DIFF
--- a/frontend/src/state/useGameEngine.test.jsx
+++ b/frontend/src/state/useGameEngine.test.jsx
@@ -126,4 +126,63 @@ describe('useGameEngine Smart10 round semantics', () => {
     expect(result.current.phase).toBe(GamePhase.GAME_OVER);
     expect(result.current.winner).toBe('Alice');
   });
+
+  test('confirmAnswer is ignored unless phase is CONFIRMING', () => {
+    const { result } = renderHook(() => useGameEngine(30));
+    act(() => {
+      result.current.startRound('Alice');
+    });
+    act(() => {
+      result.current.cardLoaded(sampleCard(0));
+    });
+    act(() => {
+      result.current.toggleOption(0);
+    });
+    act(() => {
+      result.current.confirmAnswer();
+    });
+
+    expect(result.current.phase).toBe(GamePhase.CHOOSING);
+    expect(result.current.scores.Alice).toBe(0);
+    expect(result.current.revealedIndexes.size).toBe(0);
+    expect(result.current.wrongIndexes.size).toBe(0);
+  });
+
+  test('next round resets per-round pass and elimination markers', () => {
+    const { result } = renderHook(() => useGameEngine(30));
+    act(() => {
+      result.current.startRound('Alice,Bob');
+    });
+    act(() => {
+      result.current.cardLoaded(sampleCard(0));
+    });
+    act(() => {
+      result.current.passTurn();
+    });
+    act(() => {
+      result.current.nextStep();
+    });
+    act(() => {
+      result.current.passTurn();
+    });
+    act(() => {
+      result.current.nextStep();
+    });
+
+    expect(result.current.phase).toBe(GamePhase.ROUND_SUMMARY);
+
+    act(() => {
+      result.current.nextStep();
+    });
+    expect(result.current.phase).toBe(GamePhase.LOADING_CARD);
+    expect(result.current.roundNumber).toBe(2);
+
+    act(() => {
+      result.current.cardLoaded(sampleCard(1));
+    });
+    expect(result.current.phase).toBe(GamePhase.CHOOSING);
+    expect(result.current.currentPlayer).toBe('Alice');
+    expect(result.current.eliminatedPlayers.size).toBe(0);
+    expect(result.current.passedPlayers.size).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- enforce stricter game-engine phase guards so actions only execute in valid Smart10 phases
- require CONFIRMING phase for confirmAnswer
- block choose/confirm/pass for players already passed or eliminated in current round
- clear stale selection when resolving/pass actions
- add regression tests for confirmation gating and next-round reset behavior

## Scope
- behavior-only changes in game engine semantics
- no backend/security/cors changes
- no visual/layout refactor

## How to test
- npm --prefix frontend run lint
- npm --prefix frontend run test -- --run
- npm --prefix frontend run build
- mvn -q -f backend/pom.xml test

## Smart10 semantics
- one-card round flow preserved
- turn actions now phase-safe and round-safe

Closes #88