### PR TITLE
chore(compound): document Smart10 core-flow guard loop

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -188,3 +188,12 @@
   - Users saw an opaque dark screen state with only a generic message, making backend/CORS/runtime diagnosis too slow.
 - Preventive rule:
   - Frontend setup boot must expose explicit `loading`, `backend-unreachable`, `topics-empty`, and `ready` states with retry + health-link actions.
+
+## 2026-02-18 - Loop 21 (PR89 Smart10 Core-Flow Guards Merge)
+
+- Hard part:
+  - Enforcing strict one-card round semantics without rewriting the whole engine.
+- What broke:
+  - Without phase guards, `confirmAnswer` could execute outside `CONFIRMING`, creating invalid score/reveal transitions.
+- Preventive rule:
+  - For turn-based phase machines, gate every action by phase and active-player status, and test cross-round reset behavior explicitly.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -44,3 +44,4 @@
 - For turn-based game-engine changes, include tests for pass rotation, wrong-answer elimination, round-end condition, and target-score game-over before merge.
 - For Flyway migrations that must run in both prod and tests, prefer SQL constructs proven in both Postgres and H2, and always verify with `mvn clean test` before opening PR.
 - For frontend boot/setup flow, require explicit startup-state tests for `loading`, `backend-unreachable`, `topics-empty`, and `ready` before merge.
+- For turn-based frontend engines, enforce phase guards for all player actions (`choose`, `confirm`, `pass`) and add tests proving round-state reset on next round.


### PR DESCRIPTION
## Summary
- add Loop 21 lesson entry for merged PR #89
- add explicit compound rule for phase guards + round reset tests in turn-based frontend engines

## Why
- mandatory post-merge compound update per project workflow

Closes #90