### PR TITLE
feat(ui): wheel-board polish for action clarity and player status

### DIFF
--- a/frontend/src/components/GameBoard.test.jsx
+++ b/frontend/src/components/GameBoard.test.jsx
@@ -40,16 +40,21 @@ describe('GameBoard layout', () => {
     globalThis.__setResizeObserverWidth(1024);
     render(<GameBoard {...makeProps()} />);
 
+    const shell = screen.getByTestId('wheel-board').closest('.answers-shell');
+    expect(shell).toHaveAttribute('data-layout', 'wheel');
     const wheel = screen.getByTestId('wheel-board');
     expect(wheel).toBeInTheDocument();
     expect(within(wheel).getAllByRole('button')).toHaveLength(10);
+    expect(screen.getByTestId('action-hint')).toHaveTextContent(/choose one answer/i);
   });
 
   test('falls back to grid on narrow container', () => {
     globalThis.__setResizeObserverWidth(640);
     render(<GameBoard {...makeProps()} />);
 
-    expect(screen.getByTestId('fallback-grid')).toBeInTheDocument();
+    const fallback = screen.getByTestId('fallback-grid');
+    expect(fallback).toBeInTheDocument();
+    expect(fallback.closest('.answers-shell')).toHaveAttribute('data-layout', 'fallback');
     expect(screen.queryByTestId('wheel-board')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -18,6 +18,23 @@ function getTileState(index, selectedIndexes, correctIndexes, revealedIndexes, w
   return 'hidden';
 }
 
+function actionHint(phase, currentPlayer) {
+  switch (phase) {
+    case 'CHOOSING':
+      return `${currentPlayer}: choose one answer, then press ANSWER or PASS.`;
+    case 'CONFIRMING':
+      return `${currentPlayer}: confirm with LOCK IN or go BACK.`;
+    case 'RESOLVED':
+      return 'Answer resolved. Press NEXT to continue turn flow.';
+    case 'PASSED':
+      return 'Turn passed. Press NEXT for next player or round summary.';
+    case 'LOADING_CARD':
+      return 'Loading next round card...';
+    default:
+      return 'Waiting for game state update...';
+  }
+}
+
 export default function GameBoard({
   card,
   selectedIndexes,
@@ -99,6 +116,9 @@ export default function GameBoard({
           </p>
           <h2>{card.question}</h2>
           <p className="pass-note">{passNote}</p>
+          <p className="action-hint" data-testid="action-hint">
+            {actionHint(phase, currentPlayer)}
+          </p>
         </header>
 
         <div className="answers-shell" data-layout={isFallbackLayout ? 'fallback' : 'wheel'} ref={layoutRef}>

--- a/frontend/src/components/PlayersPanel.tsx
+++ b/frontend/src/components/PlayersPanel.tsx
@@ -22,12 +22,14 @@ export default function PlayersPanel({
         {players.map((player, idx) => {
           const isOut = eliminatedPlayers.has(player);
           const isPassed = passedPlayers.has(player);
+          const isActive = idx === currentPlayerIndex;
           return (
-            <li key={player} className={idx === currentPlayerIndex ? 'active' : ''}>
-              <span>
+            <li key={player} className={isActive ? 'active' : ''}>
+              <span className="player-label">
                 {player}
-                {isOut ? ' (out)' : ''}
-                {!isOut && isPassed ? ' (passed)' : ''}
+                {isActive ? <span className="player-chip active-chip">TURN</span> : null}
+                {isOut ? <span className="player-chip out-chip">OUT</span> : null}
+                {!isOut && isPassed ? <span className="player-chip passed-chip">PASSED</span> : null}
               </span>
               <strong>{scores[player] ?? 0}</strong>
             </li>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -150,6 +150,38 @@ button:disabled {
   background: rgba(250, 181, 77, 0.18);
 }
 
+.player-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.player-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.08rem 0.35rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+}
+
+.active-chip {
+  background: rgba(249, 172, 69, 0.24);
+  border: 1px solid rgba(249, 172, 69, 0.7);
+}
+
+.out-chip {
+  background: rgba(220, 86, 86, 0.2);
+  border: 1px solid rgba(239, 111, 111, 0.7);
+}
+
+.passed-chip {
+  background: rgba(156, 171, 196, 0.2);
+  border: 1px solid rgba(178, 194, 221, 0.7);
+}
+
 .round-line {
   color: #ffd7a9;
   margin-bottom: 0.45rem;
@@ -183,6 +215,13 @@ button:disabled {
 .pass-note {
   color: #fcd1a0;
   margin-bottom: 0;
+}
+
+.action-hint {
+  margin-top: 0.6rem;
+  margin-bottom: 0;
+  color: #ffe3c2;
+  font-size: 0.92rem;
 }
 
 .answers-shell {


### PR DESCRIPTION
## Summary
- add contextual action hint text under question header (phase-aware, no behavior change)
- improve players panel readability with TURN/OUT/PASSED chips
- add stronger wheel/fallback layout assertions in component tests (data-layout checks)

## Scope guard
- layout and presentation only
- no game-engine rule changes
- no backend/security/cors changes

## How to test
- npm --prefix frontend run lint
- npm --prefix frontend run test -- --run
- npm --prefix frontend run build
- mvn -q -f backend/pom.xml test

Closes #92