### PR TITLE
chore(compound): document wheel-board polish loop learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -197,3 +197,12 @@
   - Without phase guards, `confirmAnswer` could execute outside `CONFIRMING`, creating invalid score/reveal transitions.
 - Preventive rule:
   - For turn-based phase machines, gate every action by phase and active-player status, and test cross-round reset behavior explicitly.
+
+## 2026-02-18 - Loop 22 (PR93 Wheel-Board Polish Merge)
+
+- Hard part:
+  - Improving gameplay readability without leaking into behavior/state refactors.
+- What broke:
+  - Before explicit action hints and status chips, users could misread the next legal step even though engine state was correct.
+- Preventive rule:
+  - For UI-polish PRs on turn-based games, add explicit “next action” copy and visual player-state markers, then verify with layout-scoped tests.

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -45,3 +45,4 @@
 - For Flyway migrations that must run in both prod and tests, prefer SQL constructs proven in both Postgres and H2, and always verify with `mvn clean test` before opening PR.
 - For frontend boot/setup flow, require explicit startup-state tests for `loading`, `backend-unreachable`, `topics-empty`, and `ready` before merge.
 - For turn-based frontend engines, enforce phase guards for all player actions (`choose`, `confirm`, `pass`) and add tests proving round-state reset on next round.
+- For UI-only turn-flow polish, include explicit action-hint copy and visible player status markers (`TURN`, `OUT`, `PASSED`) plus fallback/wheel layout assertions.


### PR DESCRIPTION
## Summary
- add Loop 22 lesson entry for merged PR #93 wheel-board polish
- add compound rule for UI-only turn-flow polish: action hints + player state markers + layout assertions

## Why
- mandatory post-merge compound update per workflow policy

Closes #94