### PR TITLE
fix(dev): remove local port/CORS fragility

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,30 @@ Endpoints:
 - Backend metrics: `http://localhost:8080/actuator/prometheus`
 - Internal pool stats: `http://localhost:8080/internal/pool-stats`
 
+## Local Dev Port and CORS Behavior
+
+- Vite prefers port `5173` but can move to another free localhost port when `5173` is busy.
+- Backend dev CORS accepts localhost origins on any port:
+  - `http://localhost:*`
+  - `http://127.0.0.1:*`
+- Production CORS stays strict and must use explicit `APP_CORS_ALLOWED_ORIGINS` values.
+
+Optional Windows helpers to free common dev ports:
+
+```powershell
+netstat -ano | findstr :5173
+taskkill /PID <PID> /F
+```
+
+Frontend API base URL examples:
+
+```powershell
+# local backend
+$env:VITE_API_BASE_URL="http://localhost:8080"
+# render backend
+$env:VITE_API_BASE_URL="https://<your-backend-domain>"
+```
+
 ## API Endpoints
 
 - `GET /api/topics`
@@ -131,6 +155,8 @@ Public smoke test:
 
 ```bash
 BACKEND_URL=https://<backend-domain> npm run smoke:test
+# local backend example:
+BACKEND_URL=http://localhost:8080 npm run smoke:test
 ```
 
 Stability gate (production readiness check):

--- a/backend/src/main/java/com/smartiq/backend/web/CorsConfig.java
+++ b/backend/src/main/java/com/smartiq/backend/web/CorsConfig.java
@@ -1,17 +1,23 @@
 package com.smartiq.backend.web;
 
+import com.smartiq.backend.config.CorsProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import com.smartiq.backend.config.CorsProperties;
+import org.springframework.util.StringUtils;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Configuration
-public class CorsConfig implements WebMvcConfigurer {
+public class CorsConfig {
+
+    private static final List<String> DEFAULT_DEV_ORIGINS = List.of("http://localhost:5173");
+    private static final List<String> DEV_LOCALHOST_PATTERNS = List.of("http://localhost:*", "http://127.0.0.1:*");
 
     private final CorsProperties corsProperties;
     private final Environment environment;
@@ -21,28 +27,35 @@ public class CorsConfig implements WebMvcConfigurer {
         this.environment = environment;
     }
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        List<String> allowedOrigins = resolveAllowedOrigins();
-        registry.addMapping("/api/**")
-                .allowedOrigins(allowedOrigins.toArray(new String[0]))
-                .allowedMethods("GET", "POST", "OPTIONS")
-                .allowedHeaders("Content-Type", "Authorization")
-                .allowCredentials(false);
+    @Bean
+    CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("Content-Type", "Authorization"));
+        configuration.setAllowCredentials(false);
+        configuration.setAllowedOrigins(resolveAllowedOrigins());
+
+        if (!isProdProfile()) {
+            configuration.setAllowedOriginPatterns(DEV_LOCALHOST_PATTERNS);
+        }
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+        return source;
     }
 
     private List<String> resolveAllowedOrigins() {
         String configuredCsv = environment.getProperty("APP_CORS_ALLOWED_ORIGINS", "");
         List<String> fromEnv = Arrays.stream(configuredCsv.split(","))
                 .map(String::trim)
-                .filter(value -> !value.isBlank())
+                .filter(StringUtils::hasText)
                 .collect(Collectors.toList());
 
-        List<String> resolved = fromEnv.isEmpty()
-                ? (corsProperties.allowedOrigins() == null || corsProperties.allowedOrigins().isEmpty()
-                ? List.of("http://localhost:5173")
-                : corsProperties.allowedOrigins())
-                : fromEnv;
+        List<String> fromConfig = corsProperties.allowedOrigins() == null || corsProperties.allowedOrigins().isEmpty()
+                ? DEFAULT_DEV_ORIGINS
+                : corsProperties.allowedOrigins();
+
+        List<String> resolved = fromEnv.isEmpty() ? fromConfig : fromEnv;
 
         if (isProdProfile() && resolved.stream().anyMatch("*"::equals)) {
             throw new IllegalStateException("Wildcard CORS origin is not allowed in prod.");

--- a/backend/src/test/java/com/smartiq/backend/web/CorsConfigDevTest.java
+++ b/backend/src/test/java/com/smartiq/backend/web/CorsConfigDevTest.java
@@ -1,0 +1,48 @@
+package com.smartiq.backend.web;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = {
+        "smartiq.import.enabled=false",
+        "smartiq.pool.enabled=false",
+        "smartiq.session.enabled=false",
+        "smartiq.bank.block-on-low-bank=false",
+        "spring.flyway.placeholders.seed_core_enabled=false",
+        "spring.datasource.url=jdbc:h2:mem:smartiq_cors_dev_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password="
+})
+@AutoConfigureMockMvc
+class CorsConfigDevTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void allowsGetTopicsFromLocalhostNonDefaultPortInDev() throws Exception {
+        mockMvc.perform(get("/api/topics")
+                        .header("Origin", "http://localhost:5174"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5174"));
+    }
+
+    @Test
+    void allowsPreflightForTopicsFromLocalhostNonDefaultPortInDev() throws Exception {
+        mockMvc.perform(options("/api/topics")
+                        .header("Origin", "http://localhost:5174")
+                        .header("Access-Control-Request-Method", "GET")
+                        .header("Access-Control-Request-Headers", "Content-Type"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:5174"))
+                .andExpect(header().string("Access-Control-Allow-Methods", org.hamcrest.Matchers.containsString("GET")));
+    }
+}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -18,6 +18,7 @@ Create a new Web Service from this repository:
 Set environment variables:
 
 - `SPRING_PROFILES_ACTIVE=prod`
+- `APP_CORS_ALLOWED_ORIGINS=https://<your-vercel-domain>`
 - `SPRING_DATASOURCE_URL`
 - `SPRING_DATASOURCE_USERNAME`
 - `SPRING_DATASOURCE_PASSWORD`
@@ -30,8 +31,6 @@ Set environment variables:
 - `SMARTIQ_SESSION_DEDUP_ENABLED=true`
 - `SMARTIQ_SESSION_TTL_MINUTES=120`
 - `SMARTIQ_SESSION_MAX=50000`
-- `SMARTIQ_CORS_ALLOWED_ORIGIN_PUBLIC=https://<your-vercel-domain>`
-- `SMARTIQ_CORS_ALLOWED_ORIGIN_LOCAL=http://localhost:5173`
 - `SMARTIQ_INTERNAL_ACCESS_ENABLED=true`
 - `SMARTIQ_INTERNAL_API_KEY_HEADER=X-Internal-Api-Key`
 - `SMARTIQ_INTERNAL_API_KEY=<strong-random-value>`
@@ -39,6 +38,7 @@ Set environment variables:
 Health check endpoint:
 
 - `/health`
+- Dev-only CORS convenience (`localhost:*`, `127.0.0.1:*`) is profile-gated and not active in `prod`
 - `/internal/*` now requires `X-Internal-Api-Key` in `prod`
 - `/api/admin/*` is disabled in `prod` by profile
 - Actuator in `prod` exposes only `health`, `info`, and `prometheus`

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -5,6 +5,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
-    strictPort: true
+    strictPort: false
   }
 });


### PR DESCRIPTION
## Summary\n- frontend: keep preferred Vite port 5173 but allow automatic fallback ports (strictPort: false)\n- backend: unify CORS through CorsConfigurationSource so Spring Security and MVC use the same rules\n- backend (dev-only): allow http://localhost:* and http://127.0.0.1:* origin patterns\n- production remains strict: explicit APP_CORS_ALLOWED_ORIGINS required (wildcard blocked in prod)\n- docs: clarified local-vs-prod CORS behavior and local API base URL setup\n- tests: added MockMvc CORS tests for non-default localhost port and OPTIONS preflight\n\n## Files changed\n- rontend/vite.config.js\n- ackend/src/main/java/com/smartiq/backend/web/CorsConfig.java\n- ackend/src/test/java/com/smartiq/backend/web/CorsConfigDevTest.java\n- README.md\n- docs/deploy.md\n\n## How to test\n1. 
pm --prefix frontend run lint\n2. 
pm --prefix frontend run test -- --run\n3. 
pm --prefix frontend run build\n4. mvn -q -f backend/pom.xml test\n\nManual local check:\n1. Start backend in dev profile\n2. Start frontend with 
pm --prefix frontend run dev\n3. If port 5173 is busy, Vite should move to 5174/5175 automatically\n4. Open frontend and verify requests to /api/topics succeed from that localhost port\n\n## Risk notes\n- CORS wildcard-like behavior is **dev-only** via localhost origin patterns\n- prod behavior is unchanged/strict and still driven by APP_CORS_ALLOWED_ORIGINS\n- /internal/** and /api/admin/** access rules were not relaxed\n