### PR TITLE
feat(ui): final topic selection screen

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -44,8 +44,15 @@ describe('App Smart10 round flow', () => {
     render(<App />);
 
     await waitFor(() => expect(screen.getByRole('button', { name: /start game/i })).toBeInTheDocument());
-    fireEvent.change(screen.getByLabelText(/players/i), { target: { value: 'Alice,Bob' } });
-    fireEvent.click(screen.getByRole('button', { name: /start game/i }));
+    const startButton = screen.getByRole('button', { name: /start game/i });
+    expect(startButton).toBeDisabled();
+    const playersInput = screen.getByLabelText(/players/i);
+    fireEvent.change(playersInput, { target: { value: 'Alice, Bob' } });
+    fireEvent.keyDown(playersInput, { key: 'Enter', code: 'Enter' });
+    expect(screen.getByRole('button', { name: /alice/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /bob/i })).toBeInTheDocument();
+    expect(startButton).toBeEnabled();
+    fireEvent.click(startButton);
 
     await waitFor(() => expect(screen.getByRole('button', { name: /answer/i })).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: /beta/i }));

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,11 +1,21 @@
 :root {
-  font-family: 'Trebuchet MS', 'Segoe UI', sans-serif;
+  --bg0: #261207;
+  --bg1: #110905;
+  --card: rgba(63, 29, 12, 0.9);
+  --card2: rgba(86, 40, 16, 0.78);
+  --stroke: rgba(255, 196, 137, 0.26);
+  --text: #fff1e0;
+  --muted: #e4be96;
+  --accent: #f59b1f;
+  --accent2: #ffb64c;
+  --danger: #ef6f6f;
+  --success: #7bd691;
+  font-family: "Segoe UI", "Inter", sans-serif;
   line-height: 1.4;
   font-weight: 400;
-  color: #fef9ef;
-  background:
-    radial-gradient(circle at 15% 10%, #3e220f 0%, #22120b 42%, #130b08 100%),
-    linear-gradient(180deg, #2f1408, #180b05);
+  color: var(--text);
+  background: radial-gradient(circle at 18% 8%, #4f2610 0%, var(--bg0) 42%, var(--bg1) 100%),
+    linear-gradient(180deg, #34170a, #170a05);
 }
 
 * {
@@ -18,98 +28,234 @@ body {
 }
 
 main {
-  max-width: 1200px;
+  max-width: 1160px;
   margin: 0 auto;
-  padding: 1.25rem;
-}
-
-.board-surface {
-  background: linear-gradient(180deg, #57280f, #3f1f0d);
-  border: 1px solid rgba(255, 182, 120, 0.3);
-  border-radius: 16px;
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
-}
-
-.setup-panel {
-  max-width: 560px;
-  margin: 0 auto;
-  padding: 1.4rem;
-  display: grid;
-  gap: 0.25rem;
-}
-
-.startup-panel {
-  gap: 0.5rem;
+  padding: 24px;
 }
 
 h1,
 h2,
 h3,
 p {
-  margin-top: 0;
+  margin: 0;
+}
+
+h1 {
+  font-size: clamp(2rem, 3.2vw, 2.4rem);
+  line-height: 1.1;
+  letter-spacing: 0.01em;
+  font-weight: 600;
+}
+
+.section-title {
+  margin-top: 8px;
+  font-size: 0.95rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.board-surface {
+  background: linear-gradient(180deg, var(--card2), var(--card));
+  border: 1px solid var(--stroke);
+  border-radius: 24px;
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.34);
+}
+
+.setup-panel {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 32px;
+  display: grid;
+  gap: 16px;
+}
+
+.setup-panel > p {
+  color: var(--muted);
+  font-size: 0.98rem;
+}
+
+.setup-toolbar {
+  margin-top: 8px;
+  display: inline-flex;
+  justify-self: end;
+  align-items: center;
+  gap: 8px;
+}
+
+.startup-panel {
+  max-width: 760px;
 }
 
 label {
   display: block;
-  font-weight: 700;
-  margin-top: 0.6rem;
+  font-weight: 600;
+  font-size: 0.93rem;
+  color: var(--muted);
+  margin-top: 4px;
 }
 
 select,
 input,
 button {
-  width: 100%;
-  border-radius: 10px;
-  border: 1px solid rgba(255, 213, 173, 0.3);
-  padding: 0.7rem;
-  margin-top: 0.35rem;
-  font-size: 1rem;
+  border-radius: 16px;
+  border: 1px solid var(--stroke);
+  padding: 12px 14px;
+  font-size: 0.96rem;
 }
 
 select,
 input {
-  background: rgba(255, 243, 227, 0.08);
-  color: #ffefde;
+  width: 100%;
+  background: rgba(255, 244, 228, 0.08);
+  color: var(--text);
 }
 
 button {
-  background: linear-gradient(180deg, #f59b1f, #d47117);
-  color: #2a1206;
-  font-weight: 800;
+  color: #2b1207;
+  font-weight: 700;
+  background: linear-gradient(180deg, var(--accent2), var(--accent));
   cursor: pointer;
+  transition: transform 140ms ease-out, box-shadow 140ms ease-out, border-color 140ms ease-out, background 140ms ease-out;
 }
 
 button:focus-visible,
 select:focus-visible,
 input:focus-visible {
-  outline: 2px solid #ffd094;
+  outline: 2px solid var(--accent2);
   outline-offset: 2px;
 }
 
+button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.26);
+}
+
 button:disabled {
-  opacity: 0.5;
+  opacity: 0.48;
   cursor: not-allowed;
 }
 
+.topic-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.topic-grid--skeleton {
+  opacity: 0.9;
+}
+
+.topic-tile-skeleton {
+  height: 92px;
+  border-radius: 18px;
+  border: 1px solid var(--stroke);
+  background: linear-gradient(120deg, rgba(255, 227, 187, 0.14), rgba(255, 227, 187, 0.03));
+}
+
+.topic-tile {
+  text-align: left;
+  background: rgba(255, 231, 197, 0.06);
+  color: var(--text);
+  border-radius: 18px;
+  border: 1px solid var(--stroke);
+  min-height: 96px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.topic-tile:hover {
+  border-color: rgba(255, 194, 120, 0.48);
+}
+
+.topic-tile.selected {
+  border-color: rgba(245, 155, 31, 0.9);
+  box-shadow: 0 0 0 1px rgba(245, 155, 31, 0.45), 0 12px 30px rgba(0, 0, 0, 0.32);
+  background: rgba(245, 155, 31, 0.15);
+}
+
+.topic-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.topic-count {
+  justify-self: end;
+  align-self: flex-start;
+  margin-top: 10px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--stroke);
+  color: var(--muted);
+  font-size: 0.79rem;
+  font-weight: 600;
+}
+
+.difficulty-pills {
+  display: flex;
+  gap: 8px;
+}
+
+.pill {
+  flex: 1;
+  color: var(--text);
+  background: rgba(255, 236, 208, 0.08);
+  border-radius: 999px;
+}
+
+.pill.selected {
+  background: linear-gradient(180deg, var(--accent2), var(--accent));
+  color: #2b1207;
+  border-color: rgba(255, 189, 115, 0.75);
+}
+
+.players-chips {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-height: 36px;
+}
+
+.player-token {
+  width: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 999px;
+  background: rgba(255, 233, 202, 0.12);
+  color: var(--text);
+}
+
+.field-hint {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.start-cta {
+  min-height: 48px;
+}
+
 .error {
-  color: #ffb4b4;
+  color: var(--danger);
 }
 
 .error-panel {
-  margin: 0.7rem 0;
-  padding: 0.8rem;
-  border-radius: 12px;
-  border: 1px solid rgba(245, 122, 122, 0.45);
-  background: rgba(115, 34, 34, 0.45);
+  margin: 8px 0;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(239, 111, 111, 0.5);
+  background: rgba(115, 34, 34, 0.35);
 }
 
 .startup-hint {
-  color: #ffdcb7;
+  color: var(--muted);
   margin: 0;
 }
 
 .startup-hint code {
-  color: #ffeed8;
+  color: var(--text);
 }
 
 .inline-link {
@@ -119,12 +265,12 @@ button:disabled {
 
 .game-board {
   display: grid;
-  grid-template-columns: 280px 1fr;
-  gap: 1rem;
+  grid-template-columns: 296px 1fr;
+  gap: 16px;
 }
 
 .players-panel {
-  padding: 1rem;
+  padding: 16px;
 }
 
 .players-panel ul {
@@ -132,35 +278,35 @@ button:disabled {
   padding: 0;
   margin: 0;
   display: grid;
-  gap: 0.4rem;
+  gap: 6px;
 }
 
 .players-panel li {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.55rem 0.65rem;
-  border-radius: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
   background: rgba(255, 236, 211, 0.08);
   border: 1px solid transparent;
 }
 
 .players-panel li.active {
-  border-color: #f9ac45;
-  background: rgba(250, 181, 77, 0.18);
+  border-color: rgba(249, 172, 69, 0.75);
+  background: rgba(250, 181, 77, 0.16);
 }
 
 .player-label {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
 .player-chip {
   display: inline-flex;
   align-items: center;
-  padding: 0.08rem 0.35rem;
+  padding: 2px 7px;
   border-radius: 999px;
   font-size: 0.7rem;
   font-weight: 800;
@@ -168,12 +314,12 @@ button:disabled {
 }
 
 .active-chip {
-  background: rgba(249, 172, 69, 0.24);
+  background: rgba(249, 172, 69, 0.22);
   border: 1px solid rgba(249, 172, 69, 0.7);
 }
 
 .out-chip {
-  background: rgba(220, 86, 86, 0.2);
+  background: rgba(220, 86, 86, 0.18);
   border: 1px solid rgba(239, 111, 111, 0.7);
 }
 
@@ -183,44 +329,44 @@ button:disabled {
 }
 
 .round-line {
-  color: #ffd7a9;
-  margin-bottom: 0.45rem;
+  color: var(--muted);
+  margin-bottom: 6px;
 }
 
 .center-board {
-  padding: 1rem;
+  padding: 16px;
 }
 
 .card-header {
-  margin-bottom: 0.8rem;
+  margin-bottom: 12px;
   border-bottom: 1px solid rgba(255, 204, 153, 0.2);
-  padding-bottom: 0.7rem;
+  padding-bottom: 10px;
 }
 
 .topic-pill {
   display: inline-block;
   font-weight: 700;
   font-size: 0.9rem;
-  padding: 0.2rem 0.5rem;
+  padding: 4px 10px;
   border-radius: 999px;
   background: rgba(255, 218, 168, 0.22);
 }
 
 .meta-line {
-  color: #ffd6a4;
-  margin-top: 0.3rem;
-  margin-bottom: 0.5rem;
+  color: var(--muted);
+  margin-top: 6px;
+  margin-bottom: 8px;
 }
 
 .pass-note {
   color: #fcd1a0;
-  margin-bottom: 0;
+  margin-top: 4px;
 }
 
 .action-hint {
-  margin-top: 0.6rem;
+  margin-top: 8px;
   margin-bottom: 0;
-  color: #ffe3c2;
+  color: var(--text);
   font-size: 0.92rem;
 }
 
@@ -231,7 +377,7 @@ button:disabled {
 .tile-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.55rem;
+  gap: 8px;
 }
 
 .wheel-board {
@@ -257,7 +403,7 @@ button:disabled {
   text-align: center;
   font-weight: 700;
   color: #ffd9ad;
-  padding: 0.6rem;
+  padding: 10px;
 }
 
 .wheel-slot {
@@ -269,16 +415,16 @@ button:disabled {
 
 .answer-tile {
   text-align: left;
-  padding: 0.7rem;
-  border-radius: 12px;
+  padding: 12px;
+  border-radius: 16px;
   border: 1px solid rgba(255, 199, 148, 0.35);
   background: rgba(255, 240, 224, 0.08);
-  color: #fff5e6;
+  color: var(--text);
   display: flex;
-  gap: 0.55rem;
+  gap: 8px;
   align-items: center;
-  transition: transform 140ms ease, box-shadow 140ms ease, background 140ms ease;
-  min-height: 3.2rem;
+  transition: transform 150ms ease-out, box-shadow 150ms ease-out, background 150ms ease-out;
+  min-height: 52px;
 }
 
 .answer-tile:not(:disabled):hover {
@@ -302,17 +448,17 @@ button:disabled {
 }
 
 .answer-tile.is-selected {
-  border-color: #f9ac45;
+  border-color: var(--accent2);
   background: rgba(249, 172, 69, 0.24);
 }
 
 .answer-tile.is-correct {
-  border-color: #79d78f;
+  border-color: var(--success);
   background: rgba(57, 150, 80, 0.5);
 }
 
 .answer-tile.is-wrong {
-  border-color: #ef6f6f;
+  border-color: var(--danger);
   background: rgba(167, 43, 43, 0.5);
 }
 
@@ -323,8 +469,8 @@ button:disabled {
 .action-bar {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.5rem;
-  margin-top: 0.8rem;
+  gap: 8px;
+  margin-top: 12px;
 }
 
 .action-bar button:last-child:only-child {
@@ -332,9 +478,15 @@ button:disabled {
 }
 
 .round-summary {
-  max-width: 560px;
+  max-width: 640px;
   margin: 0 auto;
-  padding: 1.25rem;
+  padding: 24px;
+}
+
+@media (min-width: 1260px) {
+  .topic-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 }
 
 @media (max-width: 980px) {
@@ -355,7 +507,28 @@ button:disabled {
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 720px) {
+  main {
+    padding: 16px;
+  }
+
+  .setup-panel {
+    padding: 24px;
+  }
+
+  .setup-toolbar {
+    justify-self: stretch;
+  }
+
+  .topic-grid,
+  .difficulty-pills {
+    grid-template-columns: 1fr;
+  }
+
+  .start-cta {
+    width: 100%;
+  }
+
   .wheel-slot {
     position: static;
     width: auto;
@@ -376,7 +549,7 @@ button:disabled {
     width: 100%;
     aspect-ratio: auto;
     border-radius: 12px;
-    margin-bottom: 0.6rem;
+    margin-bottom: 10px;
   }
 
   .tile-grid,


### PR DESCRIPTION
## Summary
- rebuilt setup screen to Smart10 final-look topic selection UX
- added topic tiles with selected/hover states and count badges
- added segmented difficulty pills and language toolbar selector
- added player chips input (enter/comma + removable chips)
- enforced Start Game gating (topic + at least one player)
- added setup skeleton and improved startup panel copy

## Files
- rontend/src/App.jsx
- rontend/src/styles.css
- rontend/src/App.startup.test.jsx
- rontend/src/App.test.jsx

## Tests run
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run test -- --run
- 
pm --prefix frontend run build
- mvn -q -f backend/pom.xml test

## Manual test
1. Start backend and frontend.
2. Confirm topic cards render, language selector works, difficulty pills toggle.
3. Add players with Enter/comma, remove chips, verify Start button gating.
4. Start game and confirm flow continues to gameplay screen.

## Risk notes
- frontend-only change; no backend/security/cors changes.
- game semantics untouched in this PR (setup UX only).