### PR TITLE
chore(compound): topic selection final UX learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -206,3 +206,13 @@
   - Before explicit action hints and status chips, users could misread the next legal step even though engine state was correct.
 - Preventive rule:
   - For UI-polish PRs on turn-based games, add explicit “next action” copy and visual player-state markers, then verify with layout-scoped tests.
+
+## 2026-02-19 - Loop 23 (PR99 Topic Selection Final UX Merge)
+
+- Hard part:
+  - Upgrading setup UX to premium tile/chip flow without breaking existing gameplay startup behavior.
+- What broke:
+  - Old setup assumptions (playersText defaulted to a player) kept CTA enabled and masked gating regressions.
+- Preventive rule:
+  - Setup CTA must be driven by parsed player chips and selected topic, not raw text defaults; enforce with startup + integration tests.
+

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -46,3 +46,4 @@
 - For frontend boot/setup flow, require explicit startup-state tests for `loading`, `backend-unreachable`, `topics-empty`, and `ready` before merge.
 - For turn-based frontend engines, enforce phase guards for all player actions (`choose`, `confirm`, `pass`) and add tests proving round-state reset on next round.
 - For UI-only turn-flow polish, include explicit action-hint copy and visible player status markers (`TURN`, `OUT`, `PASSED`) plus fallback/wheel layout assertions.
+- For setup-screen UX changes, require tests that assert Start CTA remains disabled until both topic selection and at least one parsed player chip exist.


### PR DESCRIPTION
## Summary
- added mandatory compound notes after merging PR #99
- documented startup gating regression risk and prevention rule

## Files
- docs/compound/lessons.md
- docs/compound/rules.md

## What was hard?
- preserving setup CTA gating while moving from free-text players to chip-based input.

## What broke?
- legacy default player text can silently bypass setup validation.

## What rule prevents it next time?
- require tests that keep Start disabled until topic + parsed player chips are present.