### PR TITLE
feat(ui): final game session layout

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -58,11 +58,11 @@ describe('App Smart10 round flow', () => {
     fireEvent.click(screen.getByRole('button', { name: /beta/i }));
     fireEvent.click(screen.getByRole('button', { name: /answer/i }));
     fireEvent.click(screen.getByRole('button', { name: /lock in/i }));
-    fireEvent.click(screen.getByRole('button', { name: /^next$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /next card/i }));
 
     await waitFor(() => expect(screen.getByRole('button', { name: /pass/i })).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: /pass/i }));
-    fireEvent.click(screen.getByRole('button', { name: /^next$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /next card/i }));
 
     await waitFor(() => expect(screen.getByRole('heading', { name: /round summary/i })).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: /next round/i }));

--- a/frontend/src/components/AnswerTile.tsx
+++ b/frontend/src/components/AnswerTile.tsx
@@ -1,10 +1,14 @@
 export default function AnswerTile({ index, option, state, onClick, disabled }) {
   const className = ['answer-tile', `is-${state}`].join(' ');
+  const marker = state === 'correct' ? '✓' : state === 'wrong' ? '✕' : state === 'selected' ? '●' : '';
 
   return (
     <button className={className} onClick={onClick} disabled={disabled} type="button">
       <span className="slot-index">{index + 1}</span>
       <span className="slot-text">{option}</span>
+      <span className="slot-marker" aria-hidden>
+        {marker}
+      </span>
     </button>
   );
 }

--- a/frontend/src/components/GameBoard.tsx
+++ b/frontend/src/components/GameBoard.tsx
@@ -110,15 +110,18 @@ export default function GameBoard({
 
       <div className="center-board board-surface">
         <header className="card-header">
-          <p className="topic-pill">{card.topic}</p>
-          <p className="meta-line">
-            Difficulty {card.difficulty} | {card.language}
-          </p>
+          <div className="card-topline">
+            <p className="topic-pill">
+              {card.topic} • {card.difficulty} • {card.language.toUpperCase()}
+            </p>
+            <p className="meta-line">Round {roundNumber}</p>
+          </div>
           <h2>{card.question}</h2>
-          <p className="pass-note">{passNote}</p>
+          <p className="pass-note">Choose one answer then press ANSWER or PASS.</p>
           <p className="action-hint" data-testid="action-hint">
             {actionHint(phase, currentPlayer)}
           </p>
+          <p className="pass-note">{passNote}</p>
         </header>
 
         <div className="answers-shell" data-layout={isFallbackLayout ? 'fallback' : 'wheel'} ref={layoutRef}>
@@ -182,7 +185,7 @@ export default function GameBoard({
           ) : null}
           {phase === 'RESOLVED' || phase === 'PASSED' ? (
             <button onClick={onNext} type="button">
-              NEXT
+              NEXT CARD
             </button>
           ) : null}
           {phase === 'LOADING_CARD' ? (

--- a/frontend/src/components/PlayersPanel.tsx
+++ b/frontend/src/components/PlayersPanel.tsx
@@ -12,12 +12,20 @@ export default function PlayersPanel({
 }) {
   return (
     <aside className="players-panel board-surface">
-      <h2>Players</h2>
-      <p className="round-line">Round {roundNumber}</p>
-      <p className="round-line">Turn: {currentPlayer}</p>
-      <p className="round-line">Phase: {phaseLabel}</p>
-      <p className="round-line">Target: {targetScore} points</p>
-      <p className="round-line">Last action: {lastAction}</p>
+      <h2 className="panel-title">Players</h2>
+      <div className="panel-meta">
+        <p className="round-line">Round {roundNumber}</p>
+        <p className="round-line">Target: {targetScore} pts</p>
+      </div>
+      <p className="round-line">
+        <strong>Turn:</strong> {currentPlayer}
+      </p>
+      <p className="round-line">
+        <strong>Phase:</strong> {phaseLabel}
+      </p>
+      <p className="round-line last-action">
+        <strong>Last:</strong> {lastAction}
+      </p>
       <ul>
         {players.map((player, idx) => {
           const isOut = eliminatedPlayers.has(player);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -273,6 +273,18 @@ button:disabled {
   padding: 16px;
 }
 
+.panel-title {
+  margin-bottom: 8px;
+  font-size: 1.2rem;
+}
+
+.panel-meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
 .players-panel ul {
   list-style: none;
   padding: 0;
@@ -333,6 +345,10 @@ button:disabled {
   margin-bottom: 6px;
 }
 
+.last-action {
+  margin-bottom: 12px;
+}
+
 .center-board {
   padding: 16px;
 }
@@ -341,6 +357,15 @@ button:disabled {
   margin-bottom: 12px;
   border-bottom: 1px solid rgba(255, 204, 153, 0.2);
   padding-bottom: 10px;
+  animation: panel-in 220ms ease-out;
+}
+
+.card-topline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .topic-pill {
@@ -447,6 +472,12 @@ button:disabled {
   min-width: 0;
 }
 
+.slot-marker {
+  width: 1.25rem;
+  text-align: center;
+  font-weight: 700;
+}
+
 .answer-tile.is-selected {
   border-color: var(--accent2);
   background: rgba(249, 172, 69, 0.24);
@@ -477,10 +508,25 @@ button:disabled {
   grid-column: 1 / -1;
 }
 
+.action-bar button {
+  min-height: 46px;
+}
+
 .round-summary {
   max-width: 640px;
   margin: 0 auto;
   padding: 24px;
+}
+
+@keyframes panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (min-width: 1260px) {


### PR DESCRIPTION
## Summary
- polished gameplay session screen toward Smart10 final-look
- upgraded left sidebar hierarchy (players, turn, phase, last action)
- improved card top bar metadata and round visibility
- added answer tile markers for selected/correct/wrong states
- refined control labels and visual affordance (NEXT CARD)

## Files
- rontend/src/components/GameBoard.tsx
- rontend/src/components/PlayersPanel.tsx
- rontend/src/components/AnswerTile.tsx
- rontend/src/App.test.jsx
- rontend/src/styles.css

## Tests run
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run test -- --run
- 
pm --prefix frontend run build
- mvn -q -f backend/pom.xml test

## Risk notes
- frontend-only visual/layout polish; no backend API/security changes.
- state machine semantics untouched.