### PR TITLE
chore(compound): game session layout learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -216,3 +216,13 @@
 - Preventive rule:
   - Setup CTA must be driven by parsed player chips and selected topic, not raw text defaults; enforce with startup + integration tests.
 
+
+## 2026-02-19 - Loop 24 (PR101 Game Session Final Layout Merge)
+
+- Hard part:
+  - Improving gameplay readability without touching state transitions or backend contract.
+- What broke:
+  - Button copy changes (NEXT -> NEXT CARD) broke an integration test that used exact-label matching.
+- Preventive rule:
+  - UI copy updates on action buttons must include same-PR test updates for all affected user flows.
+

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -47,3 +47,4 @@
 - For turn-based frontend engines, enforce phase guards for all player actions (`choose`, `confirm`, `pass`) and add tests proving round-state reset on next round.
 - For UI-only turn-flow polish, include explicit action-hint copy and visible player status markers (`TURN`, `OUT`, `PASSED`) plus fallback/wheel layout assertions.
 - For setup-screen UX changes, require tests that assert Start CTA remains disabled until both topic selection and at least one parsed player chip exist.
+- For gameplay action-button label changes, update UI tests in the same PR to keep behavior verification stable.


### PR DESCRIPTION
## Summary
- mandatory compound update after PR #101 merge
- documented UI action-label regression and prevention rule

## What was hard?
- layout polish changed button copy while preserving behavioral semantics.

## What broke?
- integration test selector failed after label rename.

## Rule to prevent this
- always update flow tests in same PR when gameplay action labels change.