### PR TITLE
feat(ui): summary screen with per-player stats

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -349,10 +349,22 @@ export default function App() {
     loadCard();
   }, [loadTicket, cardLoaded, cardLoadFailed, phase, sessionId, config.topic, config.difficulty, config.lang]);
 
-function handleStartRound() {
+  function handleStartRound() {
+    const freshSessionId = createFreshSession();
+    recentCardIdsRef.current = [];
+    engine.startRound(config.playersText);
+    return freshSessionId;
+  }
+
+  function createFreshSession() {
     const freshSessionId = globalThis.crypto?.randomUUID?.() || `session-${Date.now()}`;
     setSessionId(freshSessionId);
     localStorage.setItem(SESSION_STORAGE_KEY, freshSessionId);
+    return freshSessionId;
+  }
+
+  function handlePlayAgain() {
+    createFreshSession();
     recentCardIdsRef.current = [];
     engine.startRound(config.playersText);
   }
@@ -417,9 +429,11 @@ function handleStartRound() {
         <RoundSummary
           players={engine.players}
           scores={engine.scores}
+          stats={engine.stats}
           roundNumber={engine.roundNumber}
           onNextRound={engine.nextStep}
           onRestart={handleRestart}
+          onPlayAgain={handlePlayAgain}
           winner={engine.winner}
         />
       ) : null}

--- a/frontend/src/components/RoundSummary.tsx
+++ b/frontend/src/components/RoundSummary.tsx
@@ -1,25 +1,42 @@
-export default function RoundSummary({ players, scores, roundNumber, onNextRound, onRestart, winner }) {
+export default function RoundSummary({ players, scores, stats = {}, roundNumber, onNextRound, onRestart, onPlayAgain, winner }) {
   const sorted = [...players].sort((a, b) => (scores[b] ?? 0) - (scores[a] ?? 0));
 
   return (
     <section className="board-surface round-summary">
-      <h1>{winner ? 'Game Over' : 'Round Summary'}</h1>
+      <h1>{winner ? 'Game Summary' : 'Round Summary'}</h1>
       <p>{winner ? `${winner} reached 30 points.` : `Round ${roundNumber} complete.`}</p>
-      <ol>
+      <div className="summary-table" role="table" aria-label="Game summary">
+        <div className="summary-head" role="row">
+          <span role="columnheader">Player</span>
+          <span role="columnheader">Score</span>
+          <span role="columnheader">Correct</span>
+          <span role="columnheader">Wrong</span>
+          <span role="columnheader">Pass</span>
+        </div>
         {sorted.map((player) => (
-          <li key={player}>
-            {player}: <strong>{scores[player] ?? 0}</strong>
-          </li>
+          <div className="summary-row" key={player} role="row">
+            <span>{player}</span>
+            <strong>{scores[player] ?? 0}</strong>
+            <span>{stats[player]?.correct ?? 0}</span>
+            <span>{stats[player]?.wrong ?? 0}</span>
+            <span>{stats[player]?.passes ?? 0}</span>
+          </div>
         ))}
-      </ol>
-      {!winner ? (
-        <button onClick={onNextRound} type="button">
-          NEXT ROUND
+      </div>
+      <div className="summary-actions">
+        {!winner ? (
+          <button onClick={onNextRound} type="button">
+            NEXT ROUND
+          </button>
+        ) : (
+          <button onClick={onPlayAgain} type="button">
+            Play again
+          </button>
+        )}
+        <button onClick={onRestart} type="button">
+          Change topic
         </button>
-      ) : null}
-      <button onClick={onRestart} type="button">
-        Back to setup
-      </button>
+      </div>
     </section>
   );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -516,6 +516,41 @@ button:disabled {
   max-width: 640px;
   margin: 0 auto;
   padding: 24px;
+  display: grid;
+  gap: 16px;
+}
+
+.summary-table {
+  border: 1px solid var(--stroke);
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.summary-head,
+.summary-row {
+  display: grid;
+  grid-template-columns: 2fr repeat(4, 1fr);
+  gap: 8px;
+  padding: 10px 12px;
+  align-items: center;
+}
+
+.summary-head {
+  background: rgba(255, 230, 195, 0.1);
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.summary-row {
+  border-top: 1px solid rgba(255, 227, 190, 0.1);
+}
+
+.summary-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
 }
 
 @keyframes panel-in {
@@ -600,6 +635,16 @@ button:disabled {
 
   .tile-grid,
   .action-bar {
+    grid-template-columns: 1fr;
+  }
+
+  .summary-head,
+  .summary-row {
+    grid-template-columns: 1.5fr repeat(4, 1fr);
+    font-size: 0.85rem;
+  }
+
+  .summary-actions {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary
- implemented final summary screen with table-like per-player metrics
- added correct, wrong, and pass tracking in game engine
- added replay flow (Play again) and setup return (Change topic)
- kept backend contract unchanged; stats are session-local

## Files
- rontend/src/state/useGameEngine.ts
- rontend/src/components/RoundSummary.tsx
- rontend/src/App.jsx
- rontend/src/styles.css

## Tests run
- 
pm --prefix frontend run lint
- 
pm --prefix frontend run test -- --run
- 
pm --prefix frontend run build
- mvn -q -f backend/pom.xml test

## Risk notes
- summary stats are frontend-session derived (MVP-safe), not persisted backend aggregates.