### PR TITLE
chore(compound): summary screen learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -226,3 +226,12 @@
 - Preventive rule:
   - UI copy updates on action buttons must include same-PR test updates for all affected user flows.
 
+## 2026-02-19 - Loop 25 (PR103 Summary Screen Merge)
+
+- Hard part:
+  - Adding summary stats without introducing backend contract dependencies.
+- What broke:
+  - Summary render crashed when stats was missing from engine return path.
+- Preventive rule:
+  - Any newly introduced UI aggregate model must have default-safe props and be asserted in integration tests before merge.
+

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -48,3 +48,4 @@
 - For UI-only turn-flow polish, include explicit action-hint copy and visible player status markers (`TURN`, `OUT`, `PASSED`) plus fallback/wheel layout assertions.
 - For setup-screen UX changes, require tests that assert Start CTA remains disabled until both topic selection and at least one parsed player chip exist.
 - For gameplay action-button label changes, update UI tests in the same PR to keep behavior verification stable.
+- For summary/analytics UI additions, enforce null-safe default props and include one integration test covering summary render path.


### PR DESCRIPTION
## Summary
- mandatory compound update after PR #103
- documented summary-model null-safety and integration-test guard

## What was hard?
- introducing stats model without backend persistence dependency.

## What broke?
- summary crashed when stats was missing in engine return path.

## Rule to prevent it next time
- summary/analytics UI additions must be null-safe by default and covered by one integration render test.