### PR TITLE
chore(compound): error/loading polish learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -235,3 +235,13 @@
 - Preventive rule:
   - Any newly introduced UI aggregate model must have default-safe props and be asserted in integration tests before merge.
 
+
+## 2026-02-19 - Loop 26 (PR106 Error + Loading Polish Merge)
+
+- Hard part:
+  - Distinguishing transport failures from auth/cors/status failures across startup and in-game card fetch paths.
+- What broke:
+  - Users previously saw backend-unreachable copy for forbidden responses, causing wrong debugging path.
+- Preventive rule:
+  - Error mappers must explicitly branch by status class (401/403, 404, 409, 5xx, network/timeout) and be unit-tested.
+

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -49,3 +49,4 @@
 - For setup-screen UX changes, require tests that assert Start CTA remains disabled until both topic selection and at least one parsed player chip exist.
 - For gameplay action-button label changes, update UI tests in the same PR to keep behavior verification stable.
 - For summary/analytics UI additions, enforce null-safe default props and include one integration test covering summary render path.
+- For frontend API error handling, maintain a tested status-code map and never collapse 401/403 into network-unreachable messaging.


### PR DESCRIPTION
## Summary\n- capture lessons from UI error/loading polish loop after PR #106\n- codify rule to preserve distinct messaging for 401/403 vs network failures\n\n## Compound\n- What was hard: ambiguous frontend errors made ops/debug loops slow\n- What broke: forbidden responses were initially interpreted as generic unreachable states\n- Preventive rule: keep HTTP status mapping explicit and test-covered\n\n## Validation\n- docs-only change