### PR TITLE
feat(backend): activate runtime import for clean and 15k factory datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ bash tools/manual-e2e.sh
 
 - Raw card inputs live in `data/raw/`.
 - QA-approved card inputs live in `data/clean/`.
-- Import consumes only files from `data/clean/`.
+- Backend boot import scans JSON files from `data/clean` and `out` by default.
+- You can override import sources with `SMARTIQ_IMPORT_PATH` (comma-separated paths).
 - Pipeline details: `docs/data-pipeline.md`
 
 ## CI

--- a/backend/src/main/java/com/smartiq/backend/config/CardImportRunner.java
+++ b/backend/src/main/java/com/smartiq/backend/config/CardImportRunner.java
@@ -2,18 +2,23 @@ package com.smartiq.backend.config;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.smartiq.backend.card.Card;
 import com.smartiq.backend.card.CardRepository;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 @Component
 public class CardImportRunner implements ApplicationRunner {
@@ -30,27 +35,54 @@ public class CardImportRunner implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) throws Exception {
-        if (!importProperties.enabled() || cardRepository.count() > 0) {
+        if (!importProperties.enabled()) {
             return;
         }
 
-        Path importPath = Path.of(importProperties.path()).normalize();
+        resolveImportPaths(importProperties.path())
+                .forEach(this::importPath);
+    }
+
+    private void importPath(Path importPath) {
         if (!Files.exists(importPath)) {
             return;
         }
 
-        try (var fileStream = Files.list(importPath)) {
-            fileStream
-                    .filter(p -> p.getFileName().toString().endsWith(".json"))
-                    .sorted()
-                    .forEach(this::importFile);
+        if (Files.isDirectory(importPath)) {
+            try (Stream<Path> fileStream = Files.list(importPath)) {
+                fileStream
+                        .filter(p -> p.getFileName().toString().endsWith(".json"))
+                        .sorted()
+                        .forEach(this::importFile);
+            } catch (IOException ex) {
+                throw new IllegalStateException("Failed to import cards from path " + importPath, ex);
+            }
+            return;
         }
+
+        if (importPath.getFileName().toString().endsWith(".json")) {
+            importFile(importPath);
+        }
+    }
+
+    private List<Path> resolveImportPaths(String importPathRaw) {
+        if (!StringUtils.hasText(importPathRaw)) {
+            return List.of();
+        }
+
+        List<Path> paths = new ArrayList<>();
+        for (String part : importPathRaw.split(",")) {
+            if (!StringUtils.hasText(part)) {
+                continue;
+            }
+            paths.add(Path.of(part.trim()).normalize());
+        }
+        return paths;
     }
 
     private void importFile(Path path) {
         try {
-            List<CardSeed> seeds = objectMapper.readValue(Files.readString(path), new TypeReference<>() {
-            });
+            List<CardSeed> seeds = readSeeds(path);
             for (CardSeed seed : seeds) {
                 if (cardRepository.existsById(seed.id())) {
                     continue;
@@ -62,12 +94,126 @@ public class CardImportRunner implements ApplicationRunner {
         }
     }
 
+    private List<CardSeed> readSeeds(Path path) throws IOException {
+        JsonNode root = objectMapper.readTree(path.toFile());
+        if (!root.isArray() || root.isEmpty()) {
+            return List.of();
+        }
+
+        JsonNode first = root.get(0);
+        if (first.has("cards")) {
+            return readFactoryBlocks(root);
+        }
+
+        return objectMapper.convertValue(root, new TypeReference<>() {
+        });
+    }
+
+    private List<CardSeed> readFactoryBlocks(JsonNode root) {
+        List<CardSeed> seeds = new ArrayList<>();
+        for (JsonNode block : root) {
+            String topic = textOrNull(block.get("topic"));
+            String category = textOrNull(block.get("category"));
+            JsonNode cardsNode = block.get("cards");
+            if (cardsNode == null || !cardsNode.isArray()) {
+                continue;
+            }
+
+            for (JsonNode cardNode : cardsNode) {
+                String id = textOrNull(cardNode.get("id"));
+                String question = textOrNull(cardNode.get("question"));
+                String language = fallback(textOrNull(cardNode.get("language")), "en");
+                String difficulty = normalizeDifficulty(cardNode.get("difficulty"));
+                String source = fallback(textOrNull(cardNode.get("source")), "smartiq-factory");
+
+                JsonNode optionsNode = cardNode.get("options");
+                if (optionsNode == null || !optionsNode.isArray()) {
+                    continue;
+                }
+
+                List<String> options = new ArrayList<>();
+                List<Boolean> correctFlags = new ArrayList<>();
+                for (JsonNode optionNode : optionsNode) {
+                    options.add(textOrNull(optionNode.get("text")));
+                    correctFlags.add(optionNode.path("correct").asBoolean(false));
+                }
+
+                Integer correctIndex = singleCorrectIndex(correctFlags);
+                seeds.add(new CardSeed(
+                        id,
+                        topic,
+                        category,
+                        language,
+                        question,
+                        options,
+                        correctIndex,
+                        correctFlags,
+                        difficulty,
+                        source,
+                        Instant.now()
+                ));
+            }
+        }
+        return seeds;
+    }
+
+    private String normalizeDifficulty(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return "1";
+        }
+        if (node.isInt() || node.isLong()) {
+            return Integer.toString(node.asInt());
+        }
+        String value = textOrNull(node);
+        return StringUtils.hasText(value) ? value : "1";
+    }
+
+    private Integer singleCorrectIndex(List<Boolean> correctFlags) {
+        int found = -1;
+        for (int i = 0; i < correctFlags.size(); i++) {
+            if (Boolean.TRUE.equals(correctFlags.get(i))) {
+                if (found != -1) {
+                    return null;
+                }
+                found = i;
+            }
+        }
+        return found == -1 ? null : found;
+    }
+
+    private String textOrNull(JsonNode node) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        String value = node.asText(null);
+        return StringUtils.hasText(value) ? value : null;
+    }
+
+    private String fallback(String value, String defaultValue) {
+        return StringUtils.hasText(value) ? value : defaultValue;
+    }
+
+    private void requireText(String value, String message) {
+        if (!StringUtils.hasText(value)) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
     private Card toEntity(CardSeed seed) {
+        requireText(seed.id(), "Card id is required");
+        requireText(seed.topic(), "Card topic is required: " + seed.id());
+        requireText(seed.language(), "Card language is required: " + seed.id());
+        requireText(seed.question(), "Card question is required: " + seed.id());
+        requireText(seed.difficulty(), "Card difficulty is required: " + seed.id());
         if (seed.options() == null || seed.options().size() != 10) {
             throw new IllegalArgumentException("Card must contain exactly 10 options: " + seed.id());
         }
         if (seed.correctIndex() == null && (seed.correctFlags() == null || seed.correctFlags().size() != 10)) {
             throw new IllegalArgumentException("Card must include correctIndex or correctFlags: " + seed.id());
+        }
+        boolean anyCorrect = seed.correctIndex() != null || seed.correctFlags().stream().anyMatch(Boolean::booleanValue);
+        if (!anyCorrect) {
+            throw new IllegalArgumentException("Card must include at least one correct answer: " + seed.id());
         }
 
         Card card = new Card();
@@ -80,7 +226,7 @@ public class CardImportRunner implements ApplicationRunner {
         card.setCorrectIndex(seed.correctIndex());
         card.setCorrectFlags(seed.correctFlags() == null ? null : String.join(",", seed.correctFlags().stream().map(String::valueOf).toList()));
         card.setDifficulty(seed.difficulty());
-        card.setSource(seed.source());
+        card.setSource(fallback(seed.source(), "smartiq-import"));
         card.setCreatedAt(seed.createdAt() == null ? Instant.now() : seed.createdAt());
         return card;
     }
@@ -99,7 +245,10 @@ public class CardImportRunner implements ApplicationRunner {
             Instant createdAt
     ) {
         public List<String> options() {
-            return options == null ? Collections.emptyList() : options;
+            if (options == null) {
+                return Collections.emptyList();
+            }
+            return options.stream().filter(Objects::nonNull).toList();
         }
 
         public List<Boolean> correctFlags() {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -34,7 +34,7 @@ smartiq:
     time: ${SMARTIQ_BUILD_TIME:unknown}
   import:
     enabled: ${SMARTIQ_IMPORT_ENABLED:true}
-    path: ${SMARTIQ_IMPORT_PATH:../data/clean}
+    path: ${SMARTIQ_IMPORT_PATH:../data/clean,../out}
   pool:
     enabled: ${SMARTIQ_POOL_ENABLED:true}
     minimum-per-key: ${MIN_BANK_SIZE:1000}

--- a/backend/src/test/java/com/smartiq/backend/card/FactoryDatasetImportTest.java
+++ b/backend/src/test/java/com/smartiq/backend/card/FactoryDatasetImportTest.java
@@ -1,0 +1,42 @@
+package com.smartiq.backend.card;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = {
+        "smartiq.import.enabled=true",
+        "smartiq.import.path=src/test/resources/import/factory",
+        "smartiq.pool.enabled=false",
+        "smartiq.session.enabled=false",
+        "MIN_BANK_SIZE=1",
+        "spring.flyway.placeholders.seed_core_enabled=false",
+        "spring.datasource.url=jdbc:h2:mem:smartiq_factory_import_test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.username=sa",
+        "spring.datasource.password="
+})
+class FactoryDatasetImportTest {
+
+    @Autowired
+    private CardRepository cardRepository;
+
+    @Test
+    void importsFactoryDatasetBlocksOnStartup() {
+        assertThat(cardRepository.count()).isEqualTo(2);
+
+        Card first = cardRepository.findById("science_truefalse_001").orElseThrow();
+        assertThat(first.getTopic()).isEqualTo("Science");
+        assertThat(first.getSubtopic()).isEqualTo("TRUE_FALSE");
+        assertThat(first.getDifficulty()).isEqualTo("2");
+        assertThat(first.getOptions()).hasSize(10);
+        assertThat(first.getCorrectIndex()).isNull();
+        assertThat(first.getCorrectFlags()).contains("true");
+
+        Card second = cardRepository.findById("science_number_001").orElseThrow();
+        assertThat(second.getDifficulty()).isEqualTo("1");
+        assertThat(second.getCorrectIndex()).isEqualTo(0);
+    }
+}
+

--- a/backend/src/test/resources/import/factory/science.sample.json
+++ b/backend/src/test/resources/import/factory/science.sample.json
@@ -1,0 +1,51 @@
+[
+  {
+    "topic": "Science",
+    "category": "TRUE_FALSE",
+    "cards": [
+      {
+        "id": "science_truefalse_001",
+        "difficulty": 2,
+        "language": "en",
+        "question": "Which of these are true?",
+        "options": [
+          { "id": 1, "text": "Option 1", "correct": true },
+          { "id": 2, "text": "Option 2", "correct": false },
+          { "id": 3, "text": "Option 3", "correct": false },
+          { "id": 4, "text": "Option 4", "correct": false },
+          { "id": 5, "text": "Option 5", "correct": false },
+          { "id": 6, "text": "Option 6", "correct": false },
+          { "id": 7, "text": "Option 7", "correct": false },
+          { "id": 8, "text": "Option 8", "correct": false },
+          { "id": 9, "text": "Option 9", "correct": false },
+          { "id": 10, "text": "Option 10", "correct": true }
+        ]
+      }
+    ]
+  },
+  {
+    "topic": "Science",
+    "category": "NUMBER",
+    "cards": [
+      {
+        "id": "science_number_001",
+        "difficulty": 1,
+        "language": "en",
+        "question": "Pick the correct numeric answer",
+        "options": [
+          { "id": 1, "text": "42", "correct": true },
+          { "id": 2, "text": "10", "correct": false },
+          { "id": 3, "text": "11", "correct": false },
+          { "id": 4, "text": "12", "correct": false },
+          { "id": 5, "text": "13", "correct": false },
+          { "id": 6, "text": "14", "correct": false },
+          { "id": 7, "text": "15", "correct": false },
+          { "id": 8, "text": "16", "correct": false },
+          { "id": 9, "text": "17", "correct": false },
+          { "id": 10, "text": "18", "correct": false }
+        ]
+      }
+    ]
+  }
+]
+

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -5,8 +5,12 @@ SmartIQ uses a two-stage card data flow:
 - `data/raw/*.json`: generated or imported raw question sets
 - `data/clean/*.json`: QA-approved card sets used by backend import
 - `data/review/*.json`: agent-review artifacts (`approved`, `flagged`, `report`)
+- `out/*.json`: high-volume factory output (topic/category blocks with nested cards)
 
-Only files under `data/clean` are allowed as import source for the game database.
+Backend boot-time import sources are configurable via `SMARTIQ_IMPORT_PATH` (comma-separated).  
+Default order is:
+- `../data/clean`
+- `../out`
 
 ## Card Schema (MVP)
 
@@ -22,6 +26,14 @@ Each card must provide:
 - `difficulty`
 - `source`
 - `createdAt`
+
+Importer supports two JSON layouts:
+
+1. Flat card array (current `data/clean/*.json`)
+2. Factory block array (`out/*.json`) where each block contains:
+   - `topic`
+   - `category`
+   - `cards[]` with nested `options[]` objects (`text`, `correct`)
 
 ## Validation Command
 


### PR DESCRIPTION
## Summary\n- make boot-time import idempotent and always active when smartiq.import.enabled=true (removed cardRepository.count()>0 short-circuit)\n- support comma-separated import paths and scan both directories/files\n- support two JSON layouts:\n  - flat card arrays (existing data/clean/*.json)\n  - factory block arrays (out/*.json with cards[] and option objects)\n- default import path now includes both ../data/clean and ../out\n- add integration test for factory block import format\n- update docs for configurable import sources\n\n## Why\nLarge generated dataset exists in repo (out/*.json), but runtime import previously only consumed flat clean files and only on empty DB. This blocked topic discovery in frontend when DB did not contain expected content.\n\n## Tests Run\n- mvn -q -f backend/pom.xml test\n- 
pm --prefix frontend run lint\n- 
pm --prefix frontend run test -- --run\n- 
pm --prefix frontend run build\n\n## Manual Verify\n1. Start DB and backend\n2. Ensure SMARTIQ_IMPORT_ENABLED=true\n3. (optional) keep default SMARTIQ_IMPORT_PATH\n4. Call GET /api/topics -> should return non-empty topics\n5. Call GET /api/cards/next?topicId=Science&difficulty=1&sessionId=demo&lang=en -> should return card payload\n\n## Risk Notes\n- Startup import now checks files on every boot (idempotent insert via existsById) and can take longer with very large datasets; behavior is safer for content activation but adds boot-time work.\n- No security/CORS changes.