### PR TITLE
chore(compound): M6 content activation learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -245,3 +245,12 @@
 - Preventive rule:
   - Error mappers must explicitly branch by status class (401/403, 404, 409, 5xx, network/timeout) and be unit-tested.
 
+## 2026-02-19 - Loop 27 (PR109 Content Activation Import Merge)
+
+- Hard part:
+  - Activating large runtime datasets without breaking existing clean-data import flow.
+- What broke:
+  - Import runner skipped all boot import when DB already had seed rows, so new dataset files never reached API topics/cards.
+- Preventive rule:
+  - Boot import must be idempotent and format-aware (flat clean + factory blocks) instead of gated by `count()==0`.
+

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -50,3 +50,4 @@
 - For gameplay action-button label changes, update UI tests in the same PR to keep behavior verification stable.
 - For summary/analytics UI additions, enforce null-safe default props and include one integration test covering summary render path.
 - For frontend API error handling, maintain a tested status-code map and never collapse 401/403 into network-unreachable messaging.
+- For content ingestion, never gate boot import on total row count; keep import idempotent and support all approved dataset formats used in-repo.


### PR DESCRIPTION
## Summary\n- add Loop 27 lesson after PR #109\n- add a concrete rule for idempotent multi-format content ingestion\n\n## Compound\n- What was hard: activating large datasets without regressing legacy clean imports\n- What broke: row-count gate prevented boot import of newly generated content\n- Rule: boot import must be idempotent and format-aware\n\nCloses #110