### PR TITLE
fix(backend): prevent startup import failure on duplicate questions

### DIFF
--- a/backend/src/main/resources/db/migration/V2__relax_question_uniqueness.sql
+++ b/backend/src/main/resources/db/migration/V2__relax_question_uniqueness.sql
@@ -1,0 +1,4 @@
+drop index if exists uk_cards_topic_lang_question;
+
+create index if not exists idx_cards_topic_lang_question
+    on cards (topic, language, question);


### PR DESCRIPTION
## Summary\n- add Flyway migration V2__relax_question_uniqueness.sql\n- drop strict unique index uk_cards_topic_lang_question\n- add non-unique index idx_cards_topic_lang_question for lookup performance\n\n## Why\nBoot import of large generated datasets can contain repeated question text under same topic/language with different option payloads. The previous unique index caused startup failure with duplicate key value violates unique constraint uk_cards_topic_lang_question.\n\n## Validation\n- mvn -q -f backend/pom.xml test\n- 
pm --prefix frontend run lint\n- 
pm --prefix frontend run test -- --run\n- 
pm --prefix frontend run build\n\n## Local verify\n1. pull branch\n2. run backend against existing Postgres\n3. Flyway applies V2\n4. app starts without unique-constraint crash\n\nCloses #112