### PR TITLE
chore(compound): unique-constraint fix learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -254,3 +254,12 @@
 - Preventive rule:
   - Boot import must be idempotent and format-aware (flat clean + factory blocks) instead of gated by `count()==0`.
 
+## 2026-02-19 - Loop 28 (PR113 Unique-Constraint Hotfix Merge)
+
+- Hard part:
+  - Preserving large-card import flexibility while keeping database query performance acceptable.
+- What broke:
+  - Startup crashed on `uk_cards_topic_lang_question` because factory datasets legitimately repeated question text for the same topic/language.
+- Preventive rule:
+  - Do not enforce uniqueness on `(topic, language, question)` for generated banks; keep uniqueness on `id` and use non-unique lookup indexes for reads.
+

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -51,3 +51,4 @@
 - For summary/analytics UI additions, enforce null-safe default props and include one integration test covering summary render path.
 - For frontend API error handling, maintain a tested status-code map and never collapse 401/403 into network-unreachable messaging.
 - For content ingestion, never gate boot import on total row count; keep import idempotent and support all approved dataset formats used in-repo.
+- For generated question banks, avoid schema constraints that require unique question text per topic/language; enforce identity uniqueness via stable card IDs.


### PR DESCRIPTION
## Summary\n- add Loop 28 lesson after PR #113\n- add explicit rule for generated-bank uniqueness strategy\n\n## Compound\n- What was hard: balancing import flexibility with schema guarantees\n- What broke: startup crash on duplicate (topic,language,question)\n- Rule: enforce uniqueness on card IDs, not question text\n\nCloses #114