### PR TITLE
fix(backend): keep startup alive when imported cards are invalid

### DIFF
--- a/backend/src/test/java/com/smartiq/backend/card/FactoryDatasetImportTest.java
+++ b/backend/src/test/java/com/smartiq/backend/card/FactoryDatasetImportTest.java
@@ -23,7 +23,7 @@ class FactoryDatasetImportTest {
     private CardRepository cardRepository;
 
     @Test
-    void importsFactoryDatasetBlocksOnStartup() {
+    void importsFactoryDatasetBlocksOnStartupAndSkipsInvalidCards() {
         assertThat(cardRepository.count()).isEqualTo(2);
 
         Card first = cardRepository.findById("science_truefalse_001").orElseThrow();
@@ -37,6 +37,8 @@ class FactoryDatasetImportTest {
         Card second = cardRepository.findById("science_number_001").orElseThrow();
         assertThat(second.getDifficulty()).isEqualTo("1");
         assertThat(second.getCorrectIndex()).isEqualTo(0);
+
+        assertThat(cardRepository.existsById("art_number_001")).isFalse();
     }
 }
 

--- a/backend/src/test/resources/import/factory/science.sample.json
+++ b/backend/src/test/resources/import/factory/science.sample.json
@@ -44,6 +44,24 @@
           { "id": 9, "text": "17", "correct": false },
           { "id": 10, "text": "18", "correct": false }
         ]
+      },
+      {
+        "id": "art_number_001",
+        "difficulty": 1,
+        "language": "en",
+        "question": "This card is intentionally invalid",
+        "options": [
+          { "id": 1, "text": "A", "correct": false },
+          { "id": 2, "text": "B", "correct": false },
+          { "id": 3, "text": "C", "correct": false },
+          { "id": 4, "text": "D", "correct": false },
+          { "id": 5, "text": "E", "correct": false },
+          { "id": 6, "text": "F", "correct": false },
+          { "id": 7, "text": "G", "correct": false },
+          { "id": 8, "text": "H", "correct": false },
+          { "id": 9, "text": "I", "correct": false },
+          { "id": 10, "text": "J", "correct": false }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Summary\n- prevent app startup crash on single invalid imported card\n- CardImportRunner now catches per-card validation errors, logs warning, and continues import\n- add import summary logs per file: total/inserted/duplicates/invalid\n- extend factory import test data with one intentionally invalid card\n- verify invalid card is skipped while valid cards are imported\n\n## Why\nCurrent startup failed with:\nCard must include at least one correct answer: art_number_001\nThis blocked backend boot even though the rest of the dataset was valid.\n\n## Validation\n- mvn -q -f backend/pom.xml test\n- 
pm --prefix frontend run lint\n- 
pm --prefix frontend run test -- --run\n- 
pm --prefix frontend run build\n\n## Expected runtime behavior\n- backend starts successfully even if a few cards are invalid\n- invalid cards are logged and skipped\n\nCloses #116