### PR TITLE
chore(compound): import resilience hotfix learnings

### DIFF
--- a/docs/compound/lessons.md
+++ b/docs/compound/lessons.md
@@ -263,3 +263,12 @@
 - Preventive rule:
   - Do not enforce uniqueness on `(topic, language, question)` for generated banks; keep uniqueness on `id` and use non-unique lookup indexes for reads.
 
+## 2026-02-19 - Loop 29 (PR117 Import Resilience Merge)
+
+- Hard part:
+  - Keeping strict data validation while avoiding full startup failure due to one malformed card.
+- What broke:
+  - Boot import aborted application startup on the first invalid row (`no correct answer`), even though the rest of the dataset was usable.
+- Preventive rule:
+  - Import pipelines must handle per-record validation failures as skip+log events and continue processing valid records.
+

--- a/docs/compound/rules.md
+++ b/docs/compound/rules.md
@@ -52,3 +52,4 @@
 - For frontend API error handling, maintain a tested status-code map and never collapse 401/403 into network-unreachable messaging.
 - For content ingestion, never gate boot import on total row count; keep import idempotent and support all approved dataset formats used in-repo.
 - For generated question banks, avoid schema constraints that require unique question text per topic/language; enforce identity uniqueness via stable card IDs.
+- For boot-time imports, validate each card independently and continue on invalid rows with structured warning logs (`id`, `sourceFile`, `reason`).


### PR DESCRIPTION
## Summary\n- add Loop 29 lessons from PR #117\n- codify rule for per-record import failure handling\n\n## Compound\n- What was hard: preserving strict validation without startup crashes\n- What broke: a single invalid row aborted whole app boot\n- Rule: skip+log invalid rows and continue import\n\nCloses #118